### PR TITLE
Оптимизация компонента Text

### DIFF
--- a/src/shared/ui/atoms/Text/core/Text.tsx
+++ b/src/shared/ui/atoms/Text/core/Text.tsx
@@ -1,27 +1,20 @@
-import { forwardRef } from 'react'
+import { forwardRef, memo } from 'react'
 
 import { ITextProps } from '../types/ITextProps'
 
 import { useText } from './useText'
-import st from './Text.module.scss'
-import { cn } from '@shared/utils/functions'
 
-const Text = forwardRef<HTMLElement, ITextProps>((props, ref) => {
-  const { Component, children, weight, isCustomColor, className, inlineStyle } =
-    useText(props)
+const Text = memo(
+  forwardRef<HTMLElement, ITextProps>((props, ref) => {
+    const { Component, children, classes, inlineStyle } = useText(props)
 
-  return (
-    <Component
-      ref={ref as any}
-      className={cn(className, st.root, st[`weight_${weight}`], {
-        [st.root_defaultColor]: !isCustomColor,
-      })}
-      style={inlineStyle}
-    >
-      {children}
-    </Component>
-  )
-})
+    return (
+      <Component ref={ref} className={classes} style={inlineStyle}>
+        {children}
+      </Component>
+    )
+  }),
+)
 
 Text.displayName = 'Text'
 

--- a/src/shared/ui/atoms/Text/core/useText.ts
+++ b/src/shared/ui/atoms/Text/core/useText.ts
@@ -1,6 +1,9 @@
-import { CSSProperties } from 'react'
+import { useMemo } from 'react'
+import { cn } from '@shared/utils/functions'
 
 import { ITextProps } from '../types/ITextProps'
+
+import st from './Text.module.scss'
 
 const useText = (props: ITextProps) => {
   const {
@@ -13,24 +16,29 @@ const useText = (props: ITextProps) => {
     as: Component = 'div',
   } = props
 
-  const inlineStyle: CSSProperties | undefined = maxLines
-    ? {
-        ...style,
-        display: '-webkit-box',
-        WebkitBoxOrient: 'vertical',
-        WebkitLineClamp: maxLines,
-        overflow: 'hidden',
-      }
-    : style
+  const inlineStyle = useMemo(
+    () =>
+      maxLines
+        ? {
+            ...style,
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: maxLines,
+            overflow: 'hidden',
+          }
+        : style,
+    [maxLines, style],
+  )
 
-  return {
-    children,
-    weight,
-    isCustomColor,
-    className,
-    inlineStyle,
-    Component,
-  }
+  const classes = useMemo(
+    () =>
+      cn(className, st.root, st[`weight_${weight}`], {
+        [st.root_defaultColor]: !isCustomColor,
+      }),
+    [className, weight, isCustomColor],
+  )
+
+  return { Component, children, classes, inlineStyle }
 }
 
 export { useText }


### PR DESCRIPTION
## Summary
- возвращён хук `useText` и в него перенесены все вычисления стилей и классов
- компонент `Text` использует хук и содержит только JSX
- убран каст к `any` при передаче `ref`

## Testing
- `pnpm lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_689ccff872a083329e55de2636fe63f6