### PR TITLE
Упростить скрытие PlaceholderImage

### DIFF
--- a/src/shared/ui/atoms/PlaceholderImage/core/PlaceholderImage.tsx
+++ b/src/shared/ui/atoms/PlaceholderImage/core/PlaceholderImage.tsx
@@ -20,13 +20,17 @@ const PlaceholderImage = forwardRef<HTMLDivElement, IPlaceholderImageProps>(
       alt,
       handleLoad,
       handleError,
+      handleTransitionEnd,
       sizes,
     } = usePlaceholderImage(props)
 
     return (
       <div ref={ref} className={cn(st.root, className)}>
         {!isPlaceholderHidden && (
-          <div className={cn(st.blurImage, { [st.blurImage_hide]: isLoaded })}>
+          <div
+            className={cn(st.blurImage, { [st.blurImage_hide]: isLoaded })}
+            onTransitionEnd={handleTransitionEnd}
+          >
             <LogoIcon className={st.icon} />
           </div>
         )}

--- a/src/shared/ui/atoms/PlaceholderImage/core/usePlaceholderImage.ts
+++ b/src/shared/ui/atoms/PlaceholderImage/core/usePlaceholderImage.ts
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type TransitionEvent } from 'react'
 
 import { IPlaceholderImageProps } from '../types/IPlaceholderImageProps'
-import { PLACEHOLDER_DELAY } from '../static/PLACEHOLDER_DELAY'
 
 const usePlaceholderImage = (props: IPlaceholderImageProps) => {
   const { src, className = null, alt = '', sizes } = props
@@ -17,21 +16,17 @@ const usePlaceholderImage = (props: IPlaceholderImageProps) => {
     setIsLoaded(false)
   }, [])
 
+  const handleTransitionEnd = useCallback(
+    (event: TransitionEvent<HTMLDivElement>) => {
+      if (event.propertyName === 'opacity') setIsPlaceholderHidden(true)
+    },
+    [],
+  )
+
   useEffect(() => {
     setIsLoaded(false)
     setIsPlaceholderHidden(false)
   }, [src])
-
-  useEffect(() => {
-    let timer: ReturnType<typeof setTimeout>
-
-    if (isLoaded && src)
-      timer = setTimeout(() => setIsPlaceholderHidden(true), PLACEHOLDER_DELAY)
-
-    return () => {
-      if (timer) clearTimeout(timer)
-    }
-  }, [isLoaded, src])
 
   return {
     className,
@@ -41,6 +36,7 @@ const usePlaceholderImage = (props: IPlaceholderImageProps) => {
     alt,
     handleLoad,
     handleError,
+    handleTransitionEnd,
     sizes,
   }
 }

--- a/src/shared/ui/atoms/PlaceholderImage/static/PLACEHOLDER_DELAY.ts
+++ b/src/shared/ui/atoms/PlaceholderImage/static/PLACEHOLDER_DELAY.ts
@@ -1,3 +1,0 @@
-const PLACEHOLDER_DELAY = 500
-
-export { PLACEHOLDER_DELAY }


### PR DESCRIPTION
## Summary
- убрать использование таймера в PlaceholderImage
- скрывать заглушку после завершения transition

## Testing
- `pnpm lint:fix` *(fails: src/shared/ui/atoms/Skeleton/core/Skeleton.module.scss:24:9 Unexpected empty block)*

------
https://chatgpt.com/codex/tasks/task_e_689cf6a886a08332b3df02907789413e