### PR TITLE
Перевод SectionSelector на выбор по значению

### DIFF
--- a/src/shared/ui/organisms/SectionSelector/core/DynamicSectionSelector/DynamicSectionSelector.tsx
+++ b/src/shared/ui/organisms/SectionSelector/core/DynamicSectionSelector/DynamicSectionSelector.tsx
@@ -1,17 +1,20 @@
 import { cn, getEmptyArray } from '@shared/utils/functions'
 import { Skeleton } from '@shared/ui/atoms/Skeleton'
 import { Button } from '@shared/ui/molecules/Button'
-import { forwardRef } from 'react'
+import { forwardRef, ForwardedRef } from 'react'
 
-import { ISectionSelectorChildrenProps } from '../../types/ISectionSelectorChildrenProps'
+import {
+  ISectionSelectorChildrenProps,
+  ISectionSelectorComponent,
+} from '../../types/ISectionSelectorChildrenProps'
 
 import st from './DynamicSectionSelector.module.scss'
 import { useDynamicSectionSelector } from './useDynamicSectionSelector'
 
-const DynamicSectionSelector = forwardRef<
-  HTMLDivElement,
-  ISectionSelectorChildrenProps
->((props, ref) => {
+const DynamicSectionSelectorInner = <T extends string>(
+  props: ISectionSelectorChildrenProps<T>,
+  ref: ForwardedRef<HTMLDivElement>,
+) => {
   const {
     items,
     isSliderLoading,
@@ -33,14 +36,14 @@ const DynamicSectionSelector = forwardRef<
   return (
     <div ref={sliderRef} className={cn(st.root, className)}>
       <div className={st.slider}>
-        {items.map((item, index) => (
+        {items.map((item) => (
           <Button
-            key={index}
+            key={item.value}
             variant="big"
             className={cn(st.slide, {
-              [st.slide_active]: activeTab === index,
+              [st.slide_active]: activeTab === item.value,
             })}
-            onClick={() => onSwitchTab(index)}
+            onClick={() => onSwitchTab(item.value)}
           >
             {item.children}
           </Button>
@@ -49,7 +52,11 @@ const DynamicSectionSelector = forwardRef<
       </div>
     </div>
   )
-})
+}
+
+const DynamicSectionSelector = forwardRef(
+  DynamicSectionSelectorInner,
+) as ISectionSelectorComponent
 
 DynamicSectionSelector.displayName = 'DynamicSectionSelector'
 

--- a/src/shared/ui/organisms/SectionSelector/core/DynamicSectionSelector/useDynamicSectionSelector.ts
+++ b/src/shared/ui/organisms/SectionSelector/core/DynamicSectionSelector/useDynamicSectionSelector.ts
@@ -4,8 +4,8 @@ import { mergeRefs } from '@shared/utils/functions'
 
 import { ISectionSelectorChildrenProps } from '../../types/ISectionSelectorChildrenProps'
 
-const useDynamicSectionSelector = (
-  props: ISectionSelectorChildrenProps,
+const useDynamicSectionSelector = <T extends string>(
+  props: ISectionSelectorChildrenProps<T>,
   ref?: Ref<HTMLDivElement>,
 ) => {
   const { items, onSwitchTab, activeTab, className } = props

--- a/src/shared/ui/organisms/SectionSelector/core/SectionSelector.tsx
+++ b/src/shared/ui/organisms/SectionSelector/core/SectionSelector.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, ForwardedRef } from 'react'
 
 import { ISectionSelectorProps } from '../types/ISectionSelectorProps'
 
@@ -6,24 +6,16 @@ import { DynamicSectionSelector } from './DynamicSectionSelector/DynamicSectionS
 import { StaticSectionSelector } from './StaticSectionSelector/StaticSectionSelector'
 import { useSectionSelector } from './useSectionSelector'
 
-const SectionSelector = forwardRef<HTMLDivElement, ISectionSelectorProps>(
-  (props, ref) => {
-    const { className, items, onSwitchTab, variant, activeTab } =
-      useSectionSelector(props)
+const SectionSelectorInner = <T extends string>(
+  props: ISectionSelectorProps<T>,
+  ref: ForwardedRef<HTMLDivElement>,
+) => {
+  const { className, items, onSwitchTab, variant, activeTab } =
+    useSectionSelector(props)
 
-    if (variant === 'dynamic')
-      return (
-        <DynamicSectionSelector
-          ref={ref}
-          items={items}
-          className={className}
-          activeTab={activeTab}
-          onSwitchTab={onSwitchTab}
-        />
-      )
-
+  if (variant === 'dynamic')
     return (
-      <StaticSectionSelector
+      <DynamicSectionSelector
         ref={ref}
         items={items}
         className={className}
@@ -31,8 +23,19 @@ const SectionSelector = forwardRef<HTMLDivElement, ISectionSelectorProps>(
         onSwitchTab={onSwitchTab}
       />
     )
-  },
-)
+
+  return (
+    <StaticSectionSelector
+      ref={ref}
+      items={items}
+      className={className}
+      activeTab={activeTab}
+      onSwitchTab={onSwitchTab}
+    />
+  )
+}
+
+const SectionSelector = forwardRef(SectionSelectorInner)
 
 SectionSelector.displayName = 'SectionSelector'
 

--- a/src/shared/ui/organisms/SectionSelector/core/StaticSectionSelector/StaticSectionSelector.tsx
+++ b/src/shared/ui/organisms/SectionSelector/core/StaticSectionSelector/StaticSectionSelector.tsx
@@ -1,34 +1,41 @@
 import { cn } from '@shared/utils/functions'
 import { Button } from '@shared/ui/molecules/Button'
-import { forwardRef } from 'react'
+import { forwardRef, ForwardedRef } from 'react'
 
-import { ISectionSelectorChildrenProps } from '../../types/ISectionSelectorChildrenProps'
+import {
+  ISectionSelectorChildrenProps,
+  ISectionSelectorComponent,
+} from '../../types/ISectionSelectorChildrenProps'
 
 import st from './StaticSectionSelector.module.scss'
 import { useStaticSectionSelector } from './useStaticSectionSelector'
 
-const StaticSectionSelector = forwardRef<
-  HTMLDivElement,
-  ISectionSelectorChildrenProps
->((props, ref) => {
+const StaticSectionSelectorInner = <T extends string>(
+  props: ISectionSelectorChildrenProps<T>,
+  ref: ForwardedRef<HTMLDivElement>,
+) => {
   const { items, onSwitchTab, activeTab, className } =
     useStaticSectionSelector(props)
 
   return (
     <div ref={ref} className={cn(st.root, className)}>
-      {items.map((item, index) => (
+      {items.map((item) => (
         <Button
-          key={index}
+          key={item.value}
           variant="big"
-          className={cn(st.tab, { [st.tab_active]: activeTab === index })}
-          onClick={() => onSwitchTab(index)}
+          className={cn(st.tab, { [st.tab_active]: activeTab === item.value })}
+          onClick={() => onSwitchTab(item.value)}
         >
           {item.children}
         </Button>
       ))}
     </div>
   )
-})
+}
+
+const StaticSectionSelector = forwardRef(
+  StaticSectionSelectorInner,
+) as ISectionSelectorComponent
 
 StaticSectionSelector.displayName = 'StaticSectionSelector'
 

--- a/src/shared/ui/organisms/SectionSelector/core/StaticSectionSelector/useStaticSectionSelector.ts
+++ b/src/shared/ui/organisms/SectionSelector/core/StaticSectionSelector/useStaticSectionSelector.ts
@@ -1,6 +1,8 @@
 import { ISectionSelectorChildrenProps } from '../../types/ISectionSelectorChildrenProps'
 
-const useStaticSectionSelector = (props: ISectionSelectorChildrenProps) => {
+const useStaticSectionSelector = <T extends string>(
+  props: ISectionSelectorChildrenProps<T>,
+) => {
   const { items, onSwitchTab, activeTab, className } = props
 
   return { items, onSwitchTab, activeTab, className }

--- a/src/shared/ui/organisms/SectionSelector/core/useSectionSelector.ts
+++ b/src/shared/ui/organisms/SectionSelector/core/useSectionSelector.ts
@@ -1,6 +1,8 @@
 import { ISectionSelectorProps } from '../types/ISectionSelectorProps'
 
-const useSectionSelector = (props: ISectionSelectorProps) => {
+const useSectionSelector = <T extends string>(
+  props: ISectionSelectorProps<T>,
+) => {
   const {
     items = [],
     activeTab,

--- a/src/shared/ui/organisms/SectionSelector/types/ISectionSelectorChildrenProps.ts
+++ b/src/shared/ui/organisms/SectionSelector/types/ISectionSelectorChildrenProps.ts
@@ -1,11 +1,22 @@
+import { ForwardedRef, ReactElement } from 'react'
+
 import { ITabItem } from './ITabItem'
 
-interface ISectionSelectorChildrenProps {
-  items: ITabItem[]
-  activeTab: number
-  onSwitchTab: (value: number) => void
+interface ISectionSelectorChildrenProps<T extends string = string> {
+  items: ITabItem<T>[]
+  activeTab: T
+  onSwitchTab: (value: T) => void
 
   className?: string
 }
 
-export type { ISectionSelectorChildrenProps }
+interface ISectionSelectorComponent {
+  <T extends string>(
+    props: ISectionSelectorChildrenProps<T> & {
+      ref?: ForwardedRef<HTMLDivElement>
+    },
+  ): ReactElement
+  displayName?: string
+}
+
+export type { ISectionSelectorChildrenProps, ISectionSelectorComponent }

--- a/src/shared/ui/organisms/SectionSelector/types/ISectionSelectorProps.ts
+++ b/src/shared/ui/organisms/SectionSelector/types/ISectionSelectorProps.ts
@@ -1,6 +1,7 @@
 import { ISectionSelectorChildrenProps } from './ISectionSelectorChildrenProps'
 
-interface ISectionSelectorProps extends ISectionSelectorChildrenProps {
+interface ISectionSelectorProps<T extends string = string>
+  extends ISectionSelectorChildrenProps<T> {
   variant?: 'static' | 'dynamic'
 }
 

--- a/src/shared/ui/organisms/SectionSelector/types/ITabItem.ts
+++ b/src/shared/ui/organisms/SectionSelector/types/ITabItem.ts
@@ -1,7 +1,8 @@
 import { IIconProps } from '@shared/types'
 import { ComponentType } from 'react'
 
-interface ITabItem {
+interface ITabItem<T extends string = string> {
+  value: T
   children: string
 
   className?: string


### PR DESCRIPTION
## Summary
- реализован выбор секций по строковым значениям вместо индексов
- обновлены типы и компоненты SectionSelector для работы с union-значениями
- вынесен общий интерфейс компонента селектора для статического и динамического вариантов

## Testing
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68a0f88b61ec833296ec9bdfac3b7846