### PR TITLE
Улучшен хук useSession

### DIFF
--- a/src/entities/auth/hooks/useSession/core/useSession.ts
+++ b/src/entities/auth/hooks/useSession/core/useSession.ts
@@ -1,13 +1,22 @@
 import { useGetCurrentAccountWhoamiData } from '@entities/account/api/getCurrentAccountWhoamiData'
 
+import { REFETCH_INTERVAL_MS } from '../static/REFETCH_INTERVAL_MS'
+
 const useSession = () => {
   const {
     data: user = null,
     isLoading,
     isError,
-  } = useGetCurrentAccountWhoamiData({ refetchInterval: 28 * 60 * 1000 })
+    refetch,
+  } = useGetCurrentAccountWhoamiData({
+    refetchInterval: REFETCH_INTERVAL_MS,
+    staleTime: REFETCH_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+  })
 
-  return { user, isLoading, isError }
+  const isAuthenticated = Boolean(user)
+
+  return { user, isLoading, isError, isAuthenticated, refetch }
 }
 
 export { useSession }

--- a/src/entities/auth/hooks/useSession/static/REFETCH_INTERVAL_MS.ts
+++ b/src/entities/auth/hooks/useSession/static/REFETCH_INTERVAL_MS.ts
@@ -1,0 +1,3 @@
+const REFETCH_INTERVAL_MS = 28 * 60 * 1000 // 28 minutes in milliseconds
+
+export { REFETCH_INTERVAL_MS }


### PR DESCRIPTION
## Summary
- добавлен флаг `isAuthenticated` и возможность ручного `refetch`
- оптимизированы опции `useGetCurrentAccountWhoamiData`
- интервал обновления вынесен в `static/REFETCH_INTERVAL_MS` с поясняющим комментарием

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec next lint --dir src`
- `pnpm exec prettier src/entities/auth/hooks/useSession/core/useSession.ts src/entities/auth/hooks/useSession/static/REFETCH_INTERVAL_MS.ts --check`


------
https://chatgpt.com/codex/tasks/task_e_68aa41f4f27c8332bdb36ebd26e2b6f1