### PR TITLE
Разделение useQuery-хуков от createGetFetcher в GET-запросах

### DIFF
--- a/src/entities/account/api/getCurrentAccountFullData/core/getCurrentAccountFullData.ts
+++ b/src/entities/account/api/getCurrentAccountFullData/core/getCurrentAccountFullData.ts
@@ -1,21 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetCurrentAccountFullDataResponse } from '../types/IGetCurrentAccountFullDataResponse'
 
 const getCurrentAccountFullData =
   createGetFetcher<IGetCurrentAccountFullDataResponse>('/account')
 
-const useGetCurrentAccountFullData = (
-  options: TUseQueryOptions<typeof getCurrentAccountFullData> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['account'],
-    queryFn: ({ signal }) =>
-      getCurrentAccountFullData({ optionsGet: { signal } }),
-  })
-}
-
-export { useGetCurrentAccountFullData }
+export { getCurrentAccountFullData }

--- a/src/entities/account/api/getCurrentAccountFullData/core/useGetCurrentAccountFullData.ts
+++ b/src/entities/account/api/getCurrentAccountFullData/core/useGetCurrentAccountFullData.ts
@@ -1,0 +1,19 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetCurrentAccountFullDataResponse } from '../types/IGetCurrentAccountFullDataResponse'
+
+import { getCurrentAccountFullData } from './getCurrentAccountFullData'
+
+const useGetCurrentAccountFullData = (
+  options: TUseQueryOptions<typeof getCurrentAccountFullData> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['account'],
+    queryFn: ({ signal }) =>
+      getCurrentAccountFullData({ optionsGet: { signal } }),
+  })
+}
+
+export { useGetCurrentAccountFullData }

--- a/src/entities/account/api/getCurrentAccountFullData/index.ts
+++ b/src/entities/account/api/getCurrentAccountFullData/index.ts
@@ -1,1 +1,2 @@
-export { useGetCurrentAccountFullData } from './core/getCurrentAccountFullData'
+export { getCurrentAccountFullData } from './core/getCurrentAccountFullData'
+export { useGetCurrentAccountFullData } from './core/useGetCurrentAccountFullData'

--- a/src/entities/account/api/getCurrentAccountSessions/core/getCurrentAccountSessions.ts
+++ b/src/entities/account/api/getCurrentAccountSessions/core/getCurrentAccountSessions.ts
@@ -1,21 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetCurrentAccountSessionsResponse } from '../types/IGetCurrentAccountSessionsResponse'
 
 const getCurrentAccountSessions =
   createGetFetcher<IGetCurrentAccountSessionsResponse[]>('/auth/session')
 
-const useGetCurrentAccountSessions = (
-  options: TUseQueryOptions<typeof getCurrentAccountSessions> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['auth', 'session'],
-    queryFn: ({ signal }) =>
-      getCurrentAccountSessions({ optionsGet: { signal } }),
-  })
-}
-
-export { useGetCurrentAccountSessions }
+export { getCurrentAccountSessions }

--- a/src/entities/account/api/getCurrentAccountSessions/core/useGetCurrentAccountSessions.ts
+++ b/src/entities/account/api/getCurrentAccountSessions/core/useGetCurrentAccountSessions.ts
@@ -1,0 +1,19 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetCurrentAccountSessionsResponse } from '../types/IGetCurrentAccountSessionsResponse'
+
+import { getCurrentAccountSessions } from './getCurrentAccountSessions'
+
+const useGetCurrentAccountSessions = (
+  options: TUseQueryOptions<typeof getCurrentAccountSessions> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['auth', 'session'],
+    queryFn: ({ signal }) =>
+      getCurrentAccountSessions({ optionsGet: { signal } }),
+  })
+}
+
+export { useGetCurrentAccountSessions }

--- a/src/entities/account/api/getCurrentAccountSessions/index.ts
+++ b/src/entities/account/api/getCurrentAccountSessions/index.ts
@@ -1,1 +1,2 @@
-export { useGetCurrentAccountSessions } from './core/getCurrentAccountSessions'
+export { getCurrentAccountSessions } from './core/getCurrentAccountSessions'
+export { useGetCurrentAccountSessions } from './core/useGetCurrentAccountSessions'

--- a/src/entities/account/api/getCurrentAccountWhoamiData/core/getCurrentAccountWhoamiData.ts
+++ b/src/entities/account/api/getCurrentAccountWhoamiData/core/getCurrentAccountWhoamiData.ts
@@ -1,21 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetCurrentAccountWhoamiDataResponse } from '../types/IGetCurrentAccountWhoamiDataResponse'
 
 const getCurrentAccountWhoamiData =
   createGetFetcher<IGetCurrentAccountWhoamiDataResponse>('/account/whoami')
 
-const useGetCurrentAccountWhoamiData = (
-  options: TUseQueryOptions<typeof getCurrentAccountWhoamiData> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['account', 'whoami'],
-    queryFn: ({ signal }) =>
-      getCurrentAccountWhoamiData({ optionsGet: { signal } }),
-  })
-}
-
-export { useGetCurrentAccountWhoamiData }
+export { getCurrentAccountWhoamiData }

--- a/src/entities/account/api/getCurrentAccountWhoamiData/core/useGetCurrentAccountWhoamiData.ts
+++ b/src/entities/account/api/getCurrentAccountWhoamiData/core/useGetCurrentAccountWhoamiData.ts
@@ -1,0 +1,19 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetCurrentAccountWhoamiDataResponse } from '../types/IGetCurrentAccountWhoamiDataResponse'
+
+import { getCurrentAccountWhoamiData } from './getCurrentAccountWhoamiData'
+
+const useGetCurrentAccountWhoamiData = (
+  options: TUseQueryOptions<typeof getCurrentAccountWhoamiData> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['account', 'whoami'],
+    queryFn: ({ signal }) =>
+      getCurrentAccountWhoamiData({ optionsGet: { signal } }),
+  })
+}
+
+export { useGetCurrentAccountWhoamiData }

--- a/src/entities/account/api/getCurrentAccountWhoamiData/index.ts
+++ b/src/entities/account/api/getCurrentAccountWhoamiData/index.ts
@@ -1,1 +1,2 @@
-export { useGetCurrentAccountWhoamiData } from './core/getCurrentAccountWhoamiData'
+export { getCurrentAccountWhoamiData } from './core/getCurrentAccountWhoamiData'
+export { useGetCurrentAccountWhoamiData } from './core/useGetCurrentAccountWhoamiData'

--- a/src/entities/anime/api/getAnimeAdditionalInfo/core/getAnimeAdditionalInfo.ts
+++ b/src/entities/anime/api/getAnimeAdditionalInfo/core/getAnimeAdditionalInfo.ts
@@ -1,25 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAnimeAdditionalInfoResponse } from '../types/IGetAnimeAdditionalInfoResponse'
 
 const getAnimeAdditionalInfo =
   createGetFetcher<IGetAnimeAdditionalInfoResponse>('/anime/{ID}/additional')
 
-const useGetAnimeAdditionalInfo = (
-  animeID: string,
-  options: TUseQueryOptions<typeof getAnimeAdditionalInfo> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeID, 'additional'],
-    queryFn: ({ signal }) =>
-      getAnimeAdditionalInfo({
-        params: { ID: animeID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAnimeAdditionalInfo }
+export { getAnimeAdditionalInfo }

--- a/src/entities/anime/api/getAnimeAdditionalInfo/core/useGetAnimeAdditionalInfo.ts
+++ b/src/entities/anime/api/getAnimeAdditionalInfo/core/useGetAnimeAdditionalInfo.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAnimeAdditionalInfoResponse } from '../types/IGetAnimeAdditionalInfoResponse'
+
+import { getAnimeAdditionalInfo } from './getAnimeAdditionalInfo'
+
+const useGetAnimeAdditionalInfo = (
+  animeID: string,
+  options: TUseQueryOptions<typeof getAnimeAdditionalInfo> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeID, 'additional'],
+    queryFn: ({ signal }) =>
+      getAnimeAdditionalInfo({
+        params: { ID: animeID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAnimeAdditionalInfo }

--- a/src/entities/anime/api/getAnimeAdditionalInfo/index.ts
+++ b/src/entities/anime/api/getAnimeAdditionalInfo/index.ts
@@ -1,1 +1,2 @@
-export { useGetAnimeAdditionalInfo } from './core/getAnimeAdditionalInfo'
+export { getAnimeAdditionalInfo } from './core/getAnimeAdditionalInfo'
+export { useGetAnimeAdditionalInfo } from './core/useGetAnimeAdditionalInfo'

--- a/src/entities/anime/api/getAnimeEpisodePlayers/core/getAnimeEpisodePlayers.ts
+++ b/src/entities/anime/api/getAnimeEpisodePlayers/core/getAnimeEpisodePlayers.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAnimeEpisodePlayersResponse } from '../types/IGetAnimeEpisodePlayersResponse'
 
@@ -8,19 +6,4 @@ const getAnimeEpisodePlayers = createGetFetcher<
   IGetAnimeEpisodePlayersResponse[]
 >('/anime/episode/{ID}')
 
-const useGetAnimeEpisodePlayers = (
-  animeEpisodeID: string,
-  options: TUseQueryOptions<typeof getAnimeEpisodePlayers> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', 'episode', animeEpisodeID],
-    queryFn: ({ signal }) =>
-      getAnimeEpisodePlayers({
-        params: { ID: animeEpisodeID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAnimeEpisodePlayers }
+export { getAnimeEpisodePlayers }

--- a/src/entities/anime/api/getAnimeEpisodePlayers/core/useGetAnimeEpisodePlayers.ts
+++ b/src/entities/anime/api/getAnimeEpisodePlayers/core/useGetAnimeEpisodePlayers.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAnimeEpisodePlayersResponse } from '../types/IGetAnimeEpisodePlayersResponse'
+
+import { getAnimeEpisodePlayers } from './getAnimeEpisodePlayers'
+
+const useGetAnimeEpisodePlayers = (
+  animeEpisodeID: string,
+  options: TUseQueryOptions<typeof getAnimeEpisodePlayers> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', 'episode', animeEpisodeID],
+    queryFn: ({ signal }) =>
+      getAnimeEpisodePlayers({
+        params: { ID: animeEpisodeID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAnimeEpisodePlayers }

--- a/src/entities/anime/api/getAnimeEpisodePlayers/index.ts
+++ b/src/entities/anime/api/getAnimeEpisodePlayers/index.ts
@@ -1,1 +1,2 @@
-export { useGetAnimeEpisodePlayers } from './core/getAnimeEpisodePlayers'
+export { getAnimeEpisodePlayers } from './core/getAnimeEpisodePlayers'
+export { useGetAnimeEpisodePlayers } from './core/useGetAnimeEpisodePlayers'

--- a/src/entities/anime/api/getAnimeEpisodes/core/getAnimeEpisodes.ts
+++ b/src/entities/anime/api/getAnimeEpisodes/core/getAnimeEpisodes.ts
@@ -1,6 +1,4 @@
-import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAnimeEpisodesResponse } from '../types/IGetAnimeEpisodesResponse'
 
@@ -8,21 +6,4 @@ const getAnimeEpisodes = createGetFetcher<IGetAnimeEpisodesResponse>(
   '/anime/{ID}/episodes',
 )
 
-const useGetAnimeEpisodes = (
-  animeID: string,
-  additionalQuery: IPaginationQuery = {},
-  options: TUseQueryOptions<typeof getAnimeEpisodes> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeID, 'episodes'],
-    queryFn: ({ signal }) =>
-      getAnimeEpisodes({
-        params: { ID: animeID },
-        query: { ...additionalQuery },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAnimeEpisodes }
+export { getAnimeEpisodes }

--- a/src/entities/anime/api/getAnimeEpisodes/core/useGetAnimeEpisodes.ts
+++ b/src/entities/anime/api/getAnimeEpisodes/core/useGetAnimeEpisodes.ts
@@ -1,0 +1,25 @@
+import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAnimeEpisodesResponse } from '../types/IGetAnimeEpisodesResponse'
+
+import { getAnimeEpisodes } from './getAnimeEpisodes'
+
+const useGetAnimeEpisodes = (
+  animeID: string,
+  additionalQuery: IPaginationQuery = {},
+  options: TUseQueryOptions<typeof getAnimeEpisodes> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeID, 'episodes'],
+    queryFn: ({ signal }) =>
+      getAnimeEpisodes({
+        params: { ID: animeID },
+        query: { ...additionalQuery },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAnimeEpisodes }

--- a/src/entities/anime/api/getAnimeEpisodes/index.ts
+++ b/src/entities/anime/api/getAnimeEpisodes/index.ts
@@ -1,1 +1,2 @@
-export { useGetAnimeEpisodes } from './core/getAnimeEpisodes'
+export { getAnimeEpisodes } from './core/getAnimeEpisodes'
+export { useGetAnimeEpisodes } from './core/useGetAnimeEpisodes'

--- a/src/entities/anime/api/getAnimeMainInfo/core/getAnimeMainInfo.ts
+++ b/src/entities/anime/api/getAnimeMainInfo/core/getAnimeMainInfo.ts
@@ -1,25 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAnimeMainInfoResponse } from '../types/IGetAnimeMainInfoResponse'
 
 const getAnimeMainInfo =
   createGetFetcher<IGetAnimeMainInfoResponse>('/anime/{ID}')
 
-const useGetAnimeMainInfo = (
-  animeID: string,
-  options: TUseQueryOptions<typeof getAnimeMainInfo> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeID],
-    queryFn: ({ signal }) =>
-      getAnimeMainInfo({
-        params: { ID: animeID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAnimeMainInfo }
+export { getAnimeMainInfo }

--- a/src/entities/anime/api/getAnimeMainInfo/core/useGetAnimeMainInfo.ts
+++ b/src/entities/anime/api/getAnimeMainInfo/core/useGetAnimeMainInfo.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAnimeMainInfoResponse } from '../types/IGetAnimeMainInfoResponse'
+
+import { getAnimeMainInfo } from './getAnimeMainInfo'
+
+const useGetAnimeMainInfo = (
+  animeID: string,
+  options: TUseQueryOptions<typeof getAnimeMainInfo> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeID],
+    queryFn: ({ signal }) =>
+      getAnimeMainInfo({
+        params: { ID: animeID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAnimeMainInfo }

--- a/src/entities/anime/api/getAnimeMainInfo/index.ts
+++ b/src/entities/anime/api/getAnimeMainInfo/index.ts
@@ -1,1 +1,2 @@
-export { useGetAnimeMainInfo } from './core/getAnimeMainInfo'
+export { getAnimeMainInfo } from './core/getAnimeMainInfo'
+export { useGetAnimeMainInfo } from './core/useGetAnimeMainInfo'

--- a/src/entities/anime/api/getAnimeMeta/core/getAnimeMeta.ts
+++ b/src/entities/anime/api/getAnimeMeta/core/getAnimeMeta.ts
@@ -1,25 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAnimeMetaResponse } from '../types/IGetAnimeMetaResponse'
 
 const getAnimeMeta =
   createGetFetcher<IGetAnimeMetaResponse>('/anime/{slug}/meta')
 
-const useGetAnimeMeta = (
-  animeSlug: string,
-  options: TUseQueryOptions<typeof getAnimeMeta> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeSlug, 'meta'],
-    queryFn: ({ signal }) =>
-      getAnimeMeta({
-        params: { slug: animeSlug },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAnimeMeta }
+export { getAnimeMeta }

--- a/src/entities/anime/api/getAnimeMeta/core/useGetAnimeMeta.ts
+++ b/src/entities/anime/api/getAnimeMeta/core/useGetAnimeMeta.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAnimeMetaResponse } from '../types/IGetAnimeMetaResponse'
+
+import { getAnimeMeta } from './getAnimeMeta'
+
+const useGetAnimeMeta = (
+  animeSlug: string,
+  options: TUseQueryOptions<typeof getAnimeMeta> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeSlug, 'meta'],
+    queryFn: ({ signal }) =>
+      getAnimeMeta({
+        params: { slug: animeSlug },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAnimeMeta }

--- a/src/entities/anime/api/getAnimeMeta/index.ts
+++ b/src/entities/anime/api/getAnimeMeta/index.ts
@@ -1,1 +1,2 @@
-export { useGetAnimeMeta } from './core/getAnimeMeta'
+export { getAnimeMeta } from './core/getAnimeMeta'
+export { useGetAnimeMeta } from './core/useGetAnimeMeta'

--- a/src/entities/anime/api/getAnimeMiniInfo/core/getAnimeMiniInfo.ts
+++ b/src/entities/anime/api/getAnimeMiniInfo/core/getAnimeMiniInfo.ts
@@ -1,25 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAnimeMiniInfoResponse } from '../types/IGetAnimeMiniInfoResponse'
 
 const getAnimeMiniInfo =
   createGetFetcher<IGetAnimeMiniInfoResponse>('/anime/{ID}/mini')
 
-const useGetAnimeMiniInfo = (
-  animeID: string,
-  options: TUseQueryOptions<typeof getAnimeMiniInfo> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeID, 'mini'],
-    queryFn: ({ signal }) =>
-      getAnimeMiniInfo({
-        params: { ID: animeID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAnimeMiniInfo }
+export { getAnimeMiniInfo }

--- a/src/entities/anime/api/getAnimeMiniInfo/core/useGetAnimeMiniInfo.ts
+++ b/src/entities/anime/api/getAnimeMiniInfo/core/useGetAnimeMiniInfo.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAnimeMiniInfoResponse } from '../types/IGetAnimeMiniInfoResponse'
+
+import { getAnimeMiniInfo } from './getAnimeMiniInfo'
+
+const useGetAnimeMiniInfo = (
+  animeID: string,
+  options: TUseQueryOptions<typeof getAnimeMiniInfo> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeID, 'mini'],
+    queryFn: ({ signal }) =>
+      getAnimeMiniInfo({
+        params: { ID: animeID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAnimeMiniInfo }

--- a/src/entities/anime/api/getAnimeMiniInfo/index.ts
+++ b/src/entities/anime/api/getAnimeMiniInfo/index.ts
@@ -1,1 +1,2 @@
-export { useGetAnimeMiniInfo } from './core/getAnimeMiniInfo'
+export { getAnimeMiniInfo } from './core/getAnimeMiniInfo'
+export { useGetAnimeMiniInfo } from './core/useGetAnimeMiniInfo'

--- a/src/entities/anime/api/getFriendsStatus/core/getFriendsStatus.ts
+++ b/src/entities/anime/api/getFriendsStatus/core/getFriendsStatus.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetFriendsStatusResponse } from '../types/IGetFriendsStatusResponse'
 
@@ -8,19 +6,4 @@ const getFriendsStatus = createGetFetcher<IGetFriendsStatusResponse[]>(
   '/anime/{ID}/friendsStatus',
 )
 
-const useGetFriendsStatus = (
-  animeID: string,
-  options: TUseQueryOptions<typeof getFriendsStatus> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeID, 'friendsStatus'],
-    queryFn: ({ signal }) =>
-      getFriendsStatus({
-        params: { ID: animeID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetFriendsStatus }
+export { getFriendsStatus }

--- a/src/entities/anime/api/getFriendsStatus/core/useGetFriendsStatus.ts
+++ b/src/entities/anime/api/getFriendsStatus/core/useGetFriendsStatus.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetFriendsStatusResponse } from '../types/IGetFriendsStatusResponse'
+
+import { getFriendsStatus } from './getFriendsStatus'
+
+const useGetFriendsStatus = (
+  animeID: string,
+  options: TUseQueryOptions<typeof getFriendsStatus> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeID, 'friendsStatus'],
+    queryFn: ({ signal }) =>
+      getFriendsStatus({
+        params: { ID: animeID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetFriendsStatus }

--- a/src/entities/anime/api/getFriendsStatus/index.ts
+++ b/src/entities/anime/api/getFriendsStatus/index.ts
@@ -1,1 +1,2 @@
-export { useGetFriendsStatus } from './core/getFriendsStatus'
+export { getFriendsStatus } from './core/getFriendsStatus'
+export { useGetFriendsStatus } from './core/useGetFriendsStatus'

--- a/src/entities/anime/api/getUserCurrentAnimeReactions/core/getUserCurrentAnimeReactions.ts
+++ b/src/entities/anime/api/getUserCurrentAnimeReactions/core/getUserCurrentAnimeReactions.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetUserCurrentAnimeReactionsResponse } from '../types/IGetUserCurrentAnimeReactionsResponse'
 
@@ -9,19 +7,4 @@ const getUserCurrentAnimeReactions =
     '/anime/{ID}/userAnimeReactions',
   )
 
-const useGetUserCurrentAnimeReactions = (
-  animeID: string,
-  options: TUseQueryOptions<typeof getUserCurrentAnimeReactions> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeID, 'userAnimeReactions'],
-    queryFn: ({ signal }) =>
-      getUserCurrentAnimeReactions({
-        params: { ID: animeID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserCurrentAnimeReactions }
+export { getUserCurrentAnimeReactions }

--- a/src/entities/anime/api/getUserCurrentAnimeReactions/core/useGetUserCurrentAnimeReactions.ts
+++ b/src/entities/anime/api/getUserCurrentAnimeReactions/core/useGetUserCurrentAnimeReactions.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetUserCurrentAnimeReactionsResponse } from '../types/IGetUserCurrentAnimeReactionsResponse'
+
+import { getUserCurrentAnimeReactions } from './getUserCurrentAnimeReactions'
+
+const useGetUserCurrentAnimeReactions = (
+  animeID: string,
+  options: TUseQueryOptions<typeof getUserCurrentAnimeReactions> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeID, 'userAnimeReactions'],
+    queryFn: ({ signal }) =>
+      getUserCurrentAnimeReactions({
+        params: { ID: animeID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserCurrentAnimeReactions }

--- a/src/entities/anime/api/getUserCurrentAnimeReactions/index.ts
+++ b/src/entities/anime/api/getUserCurrentAnimeReactions/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserCurrentAnimeReactions } from './core/getUserCurrentAnimeReactions'
+export { getUserCurrentAnimeReactions } from './core/getUserCurrentAnimeReactions'
+export { useGetUserCurrentAnimeReactions } from './core/useGetUserCurrentAnimeReactions'

--- a/src/entities/anime/api/getUserEpisodesData/core/getUserEpisodesData.ts
+++ b/src/entities/anime/api/getUserEpisodesData/core/getUserEpisodesData.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetUserEpisodesDataResponse } from '../types/IGetUserEpisodesDataResponse'
 
@@ -8,19 +6,4 @@ const getUserEpisodesData = createGetFetcher<IGetUserEpisodesDataResponse[]>(
   '/anime/{ID}/userEpisodes',
 )
 
-const useGetUserEpisodesData = (
-  animeID: string,
-  options: TUseQueryOptions<typeof getUserEpisodesData> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['anime', animeID, 'userEpisodes'],
-    queryFn: ({ signal }) =>
-      getUserEpisodesData({
-        params: { ID: animeID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserEpisodesData }
+export { getUserEpisodesData }

--- a/src/entities/anime/api/getUserEpisodesData/core/useGetUserEpisodesData.ts
+++ b/src/entities/anime/api/getUserEpisodesData/core/useGetUserEpisodesData.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetUserEpisodesDataResponse } from '../types/IGetUserEpisodesDataResponse'
+
+import { getUserEpisodesData } from './getUserEpisodesData'
+
+const useGetUserEpisodesData = (
+  animeID: string,
+  options: TUseQueryOptions<typeof getUserEpisodesData> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['anime', animeID, 'userEpisodes'],
+    queryFn: ({ signal }) =>
+      getUserEpisodesData({
+        params: { ID: animeID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserEpisodesData }

--- a/src/entities/anime/api/getUserEpisodesData/index.ts
+++ b/src/entities/anime/api/getUserEpisodesData/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserEpisodesData } from './core/getUserEpisodesData'
+export { getUserEpisodesData } from './core/getUserEpisodesData'
+export { useGetUserEpisodesData } from './core/useGetUserEpisodesData'

--- a/src/entities/apps/api/getAniBattleList/core/getAniBattleList.ts
+++ b/src/entities/apps/api/getAniBattleList/core/getAniBattleList.ts
@@ -1,23 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAniBattleListResponse } from '../types/IGetAniBattleListResponse'
 
 const getAniBattleList =
   createGetFetcher<IGetAniBattleListResponse>('/aniBattle')
 
-const useGetAniBattleList = (
-  options: TUseQueryOptions<typeof getAniBattleList> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['aniBattle'],
-    queryFn: ({ signal }) =>
-      getAniBattleList({
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAniBattleList }
+export { getAniBattleList }

--- a/src/entities/apps/api/getAniBattleList/core/useGetAniBattleList.ts
+++ b/src/entities/apps/api/getAniBattleList/core/useGetAniBattleList.ts
@@ -1,0 +1,21 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAniBattleListResponse } from '../types/IGetAniBattleListResponse'
+
+import { getAniBattleList } from './getAniBattleList'
+
+const useGetAniBattleList = (
+  options: TUseQueryOptions<typeof getAniBattleList> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['aniBattle'],
+    queryFn: ({ signal }) =>
+      getAniBattleList({
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAniBattleList }

--- a/src/entities/apps/api/getAniBattleList/index.ts
+++ b/src/entities/apps/api/getAniBattleList/index.ts
@@ -1,1 +1,2 @@
-export { useGetAniBattleList } from './core/getAniBattleList'
+export { getAniBattleList } from './core/getAniBattleList'
+export { useGetAniBattleList } from './core/useGetAniBattleList'

--- a/src/entities/apps/api/getAniJudgeList/core/getAniJudgeList.ts
+++ b/src/entities/apps/api/getAniJudgeList/core/getAniJudgeList.ts
@@ -1,23 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAniJudgeListResponse } from '../types/IGetAniJudgeListResponse'
 
 const getAniJudgeList =
   createGetFetcher<IGetAniJudgeListResponse[]>('/aniJudge')
 
-const useGetAniJudgeList = (
-  options: TUseQueryOptions<typeof getAniJudgeList> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['aniJudge'],
-    queryFn: ({ signal }) =>
-      getAniJudgeList({
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAniJudgeList }
+export { getAniJudgeList }

--- a/src/entities/apps/api/getAniJudgeList/core/useGetAniJudgeList.ts
+++ b/src/entities/apps/api/getAniJudgeList/core/useGetAniJudgeList.ts
@@ -1,0 +1,21 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAniJudgeListResponse } from '../types/IGetAniJudgeListResponse'
+
+import { getAniJudgeList } from './getAniJudgeList'
+
+const useGetAniJudgeList = (
+  options: TUseQueryOptions<typeof getAniJudgeList> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['aniJudge'],
+    queryFn: ({ signal }) =>
+      getAniJudgeList({
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAniJudgeList }

--- a/src/entities/apps/api/getAniJudgeList/index.ts
+++ b/src/entities/apps/api/getAniJudgeList/index.ts
@@ -1,1 +1,2 @@
-export { useGetAniJudgeList } from './core/getAniJudgeList'
+export { getAniJudgeList } from './core/getAniJudgeList'
+export { useGetAniJudgeList } from './core/useGetAniJudgeList'

--- a/src/entities/apps/api/getAniPickList/core/getAniPickList.ts
+++ b/src/entities/apps/api/getAniPickList/core/getAniPickList.ts
@@ -1,28 +1,7 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
-import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
 
 import { IGetAniPickListResponse } from '../types/IGetAniPickListResponse'
 
 const getAniPickList = createGetFetcher<IGetAniPickListResponse[]>('/aniPick')
 
-const useGetAniPickList = (
-  additionalQuery: Pick<
-    IAnimeFIltersAndSort,
-    'endDate' | 'startDate' | 'rating' | 'kind' | 'season' | 'status'
-  > = {},
-  options: TUseQueryOptions<typeof getAniPickList> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['aniPick'],
-    queryFn: ({ signal }) =>
-      getAniPickList({
-        query: { ...additionalQuery },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAniPickList }
+export { getAniPickList }

--- a/src/entities/apps/api/getAniPickList/core/useGetAniPickList.ts
+++ b/src/entities/apps/api/getAniPickList/core/useGetAniPickList.ts
@@ -1,0 +1,27 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
+
+import { IGetAniPickListResponse } from '../types/IGetAniPickListResponse'
+
+import { getAniPickList } from './getAniPickList'
+
+const useGetAniPickList = (
+  additionalQuery: Pick<
+    IAnimeFIltersAndSort,
+    'endDate' | 'startDate' | 'rating' | 'kind' | 'season' | 'status'
+  > = {},
+  options: TUseQueryOptions<typeof getAniPickList> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['aniPick'],
+    queryFn: ({ signal }) =>
+      getAniPickList({
+        query: { ...additionalQuery },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAniPickList }

--- a/src/entities/apps/api/getAniPickList/index.ts
+++ b/src/entities/apps/api/getAniPickList/index.ts
@@ -1,1 +1,2 @@
-export { useGetAniPickList } from './core/getAniPickList'
+export { getAniPickList } from './core/getAniPickList'
+export { useGetAniPickList } from './core/useGetAniPickList'

--- a/src/entities/club/api/getClubAnimeList/core/getClubAnimeList.ts
+++ b/src/entities/club/api/getClubAnimeList/core/getClubAnimeList.ts
@@ -1,7 +1,4 @@
-import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
-import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
 
 import { IGetClubAnimeListResponse } from '../types/IGetClubAnimeListResponse'
 
@@ -9,21 +6,4 @@ const getClubAnimeList = createGetFetcher<IGetClubAnimeListResponse>(
   '/club/{ID}/animeList',
 )
 
-const useGetClubAnimeList = (
-  clubID: string,
-  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
-  options: TUseQueryOptions<typeof getClubAnimeList> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['club', clubID, 'animeList'],
-    queryFn: ({ signal }) =>
-      getClubAnimeList({
-        params: { ID: clubID },
-        query: { ...additionalQuery },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetClubAnimeList }
+export { getClubAnimeList }

--- a/src/entities/club/api/getClubAnimeList/core/useGetClubAnimeList.ts
+++ b/src/entities/club/api/getClubAnimeList/core/useGetClubAnimeList.ts
@@ -1,0 +1,26 @@
+import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
+
+import { IGetClubAnimeListResponse } from '../types/IGetClubAnimeListResponse'
+
+import { getClubAnimeList } from './getClubAnimeList'
+
+const useGetClubAnimeList = (
+  clubID: string,
+  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
+  options: TUseQueryOptions<typeof getClubAnimeList> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['club', clubID, 'animeList'],
+    queryFn: ({ signal }) =>
+      getClubAnimeList({
+        params: { ID: clubID },
+        query: { ...additionalQuery },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetClubAnimeList }

--- a/src/entities/club/api/getClubAnimeList/index.ts
+++ b/src/entities/club/api/getClubAnimeList/index.ts
@@ -1,1 +1,2 @@
-export { useGetClubAnimeList } from './core/getClubAnimeList'
+export { getClubAnimeList } from './core/getClubAnimeList'
+export { useGetClubAnimeList } from './core/useGetClubAnimeList'

--- a/src/entities/club/api/getClubMainInfo/core/getClubMainInfo.ts
+++ b/src/entities/club/api/getClubMainInfo/core/getClubMainInfo.ts
@@ -1,24 +1,7 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetClubMainInfoResponse } from '../types/IGetClubMainInfoResponse'
 
 const getClubMainInfo = createGetFetcher<IGetClubMainInfoResponse>('/club/{ID}')
 
-const useGetClubMainInfo = (
-  clubID: string,
-  options: TUseQueryOptions<typeof getClubMainInfo> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['club', clubID],
-    queryFn: ({ signal }) =>
-      getClubMainInfo({
-        params: { ID: clubID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetClubMainInfo }
+export { getClubMainInfo }

--- a/src/entities/club/api/getClubMainInfo/core/useGetClubMainInfo.ts
+++ b/src/entities/club/api/getClubMainInfo/core/useGetClubMainInfo.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetClubMainInfoResponse } from '../types/IGetClubMainInfoResponse'
+
+import { getClubMainInfo } from './getClubMainInfo'
+
+const useGetClubMainInfo = (
+  clubID: string,
+  options: TUseQueryOptions<typeof getClubMainInfo> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['club', clubID],
+    queryFn: ({ signal }) =>
+      getClubMainInfo({
+        params: { ID: clubID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetClubMainInfo }

--- a/src/entities/club/api/getClubMainInfo/index.ts
+++ b/src/entities/club/api/getClubMainInfo/index.ts
@@ -1,1 +1,2 @@
-export { useGetClubMainInfo } from './core/getClubMainInfo'
+export { getClubMainInfo } from './core/getClubMainInfo'
+export { useGetClubMainInfo } from './core/useGetClubMainInfo'

--- a/src/entities/club/api/getClubMeta/core/getClubMeta.ts
+++ b/src/entities/club/api/getClubMeta/core/getClubMeta.ts
@@ -1,24 +1,7 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetClubMetaResponse } from '../types/IGetClubMetaResponse'
 
 const getClubMeta = createGetFetcher<IGetClubMetaResponse>('/club/{slug}/meta')
 
-const useGetClubMeta = (
-  clubSlug: string,
-  options: TUseQueryOptions<typeof getClubMeta> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['club', clubSlug, 'meta'],
-    queryFn: ({ signal }) =>
-      getClubMeta({
-        params: { slug: clubSlug },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetClubMeta }
+export { getClubMeta }

--- a/src/entities/club/api/getClubMeta/core/useGetClubMeta.ts
+++ b/src/entities/club/api/getClubMeta/core/useGetClubMeta.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetClubMetaResponse } from '../types/IGetClubMetaResponse'
+
+import { getClubMeta } from './getClubMeta'
+
+const useGetClubMeta = (
+  clubSlug: string,
+  options: TUseQueryOptions<typeof getClubMeta> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['club', clubSlug, 'meta'],
+    queryFn: ({ signal }) =>
+      getClubMeta({
+        params: { slug: clubSlug },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetClubMeta }

--- a/src/entities/club/api/getClubMeta/index.ts
+++ b/src/entities/club/api/getClubMeta/index.ts
@@ -1,1 +1,2 @@
-export { useGetClubMeta } from './core/getClubMeta'
+export { getClubMeta } from './core/getClubMeta'
+export { useGetClubMeta } from './core/useGetClubMeta'

--- a/src/entities/club/api/getUserClubAnimesReactionData/core/getUserClubAnimesReactionData.ts
+++ b/src/entities/club/api/getUserClubAnimesReactionData/core/getUserClubAnimesReactionData.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetUserClubAnimesReactionDataResponse } from '../types/IGetUserClubAnimesReactionDataResponse'
 
@@ -8,19 +6,4 @@ const getUserClubAnimesReactionData = createGetFetcher<
   IGetUserClubAnimesReactionDataResponse[]
 >('/club/{ID}/userAnimeReactions')
 
-const useGetUserClubAnimesReactionData = (
-  clubID: string,
-  options: TUseQueryOptions<typeof getUserClubAnimesReactionData> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['club', clubID, 'userAnimeReactions'],
-    queryFn: ({ signal }) =>
-      getUserClubAnimesReactionData({
-        params: { ID: clubID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserClubAnimesReactionData }
+export { getUserClubAnimesReactionData }

--- a/src/entities/club/api/getUserClubAnimesReactionData/core/useGetUserClubAnimesReactionData.ts
+++ b/src/entities/club/api/getUserClubAnimesReactionData/core/useGetUserClubAnimesReactionData.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetUserClubAnimesReactionDataResponse } from '../types/IGetUserClubAnimesReactionDataResponse'
+
+import { getUserClubAnimesReactionData } from './getUserClubAnimesReactionData'
+
+const useGetUserClubAnimesReactionData = (
+  clubID: string,
+  options: TUseQueryOptions<typeof getUserClubAnimesReactionData> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['club', clubID, 'userAnimeReactions'],
+    queryFn: ({ signal }) =>
+      getUserClubAnimesReactionData({
+        params: { ID: clubID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserClubAnimesReactionData }

--- a/src/entities/club/api/getUserClubAnimesReactionData/index.ts
+++ b/src/entities/club/api/getUserClubAnimesReactionData/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserClubAnimesReactionData } from './core/getUserClubAnimesReactionData'
+export { getUserClubAnimesReactionData } from './core/getUserClubAnimesReactionData'
+export { useGetUserClubAnimesReactionData } from './core/useGetUserClubAnimesReactionData'

--- a/src/entities/collection/api/getCollectionAnimeList/core/getCollectionAnimeList.ts
+++ b/src/entities/collection/api/getCollectionAnimeList/core/getCollectionAnimeList.ts
@@ -1,8 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
-import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
-import { IPaginationQuery } from '@shared/types/IPaginationQuery'
 
 import { IGetCollectionAnimeListResponse } from '../types/IGetCollectionAnimeListResponse'
 
@@ -11,21 +7,4 @@ const getCollectionAnimeList =
     '/collection/{ID}/animeList',
   )
 
-const useGetCollectionAnimeList = (
-  collectionID: string,
-  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
-  options: TUseQueryOptions<typeof getCollectionAnimeList> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['collection', collectionID, 'animeList'],
-    queryFn: ({ signal }) =>
-      getCollectionAnimeList({
-        params: { ID: collectionID },
-        query: { ...additionalQuery },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetCollectionAnimeList }
+export { getCollectionAnimeList }

--- a/src/entities/collection/api/getCollectionAnimeList/core/useGetCollectionAnimeList.ts
+++ b/src/entities/collection/api/getCollectionAnimeList/core/useGetCollectionAnimeList.ts
@@ -1,0 +1,27 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
+import { IPaginationQuery } from '@shared/types/IPaginationQuery'
+
+import { IGetCollectionAnimeListResponse } from '../types/IGetCollectionAnimeListResponse'
+
+import { getCollectionAnimeList } from './getCollectionAnimeList'
+
+const useGetCollectionAnimeList = (
+  collectionID: string,
+  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
+  options: TUseQueryOptions<typeof getCollectionAnimeList> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['collection', collectionID, 'animeList'],
+    queryFn: ({ signal }) =>
+      getCollectionAnimeList({
+        params: { ID: collectionID },
+        query: { ...additionalQuery },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetCollectionAnimeList }

--- a/src/entities/collection/api/getCollectionAnimeList/index.ts
+++ b/src/entities/collection/api/getCollectionAnimeList/index.ts
@@ -1,1 +1,2 @@
-export { useGetCollectionAnimeList } from './core/getCollectionAnimeList'
+export { getCollectionAnimeList } from './core/getCollectionAnimeList'
+export { useGetCollectionAnimeList } from './core/useGetCollectionAnimeList'

--- a/src/entities/collection/api/getCollectionMainInfo/core/getCollectionMainInfo.ts
+++ b/src/entities/collection/api/getCollectionMainInfo/core/getCollectionMainInfo.ts
@@ -1,25 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetCollectionMainInfoResponse } from '../types/IGetCollectionMainInfoResponse'
 
 const getCollectionMainInfo =
   createGetFetcher<IGetCollectionMainInfoResponse>('/collection/{ID}')
 
-const useGetCollectionMainInfo = (
-  collectionID: string,
-  options: TUseQueryOptions<typeof getCollectionMainInfo> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['collection', collectionID],
-    queryFn: ({ signal }) =>
-      getCollectionMainInfo({
-        params: { ID: collectionID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetCollectionMainInfo }
+export { getCollectionMainInfo }

--- a/src/entities/collection/api/getCollectionMainInfo/core/useGetCollectionMainInfo.ts
+++ b/src/entities/collection/api/getCollectionMainInfo/core/useGetCollectionMainInfo.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetCollectionMainInfoResponse } from '../types/IGetCollectionMainInfoResponse'
+
+import { getCollectionMainInfo } from './getCollectionMainInfo'
+
+const useGetCollectionMainInfo = (
+  collectionID: string,
+  options: TUseQueryOptions<typeof getCollectionMainInfo> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['collection', collectionID],
+    queryFn: ({ signal }) =>
+      getCollectionMainInfo({
+        params: { ID: collectionID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetCollectionMainInfo }

--- a/src/entities/collection/api/getCollectionMainInfo/index.ts
+++ b/src/entities/collection/api/getCollectionMainInfo/index.ts
@@ -1,1 +1,2 @@
-export { useGetCollectionMainInfo } from './core/getCollectionMainInfo'
+export { getCollectionMainInfo } from './core/getCollectionMainInfo'
+export { useGetCollectionMainInfo } from './core/useGetCollectionMainInfo'

--- a/src/entities/collection/api/getCollectionMeta/core/getCollectionMeta.ts
+++ b/src/entities/collection/api/getCollectionMeta/core/getCollectionMeta.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetCollectionMetaResponse } from '../types/IGetCollectionMetaResponse'
 
@@ -8,19 +6,4 @@ const getCollectionMeta = createGetFetcher<IGetCollectionMetaResponse>(
   '/collection/{slug}/meta',
 )
 
-const useGetCollectionMeta = (
-  collectionSlug: string,
-  options: TUseQueryOptions<typeof getCollectionMeta> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['collection', collectionSlug, 'meta'],
-    queryFn: ({ signal }) =>
-      getCollectionMeta({
-        params: { slug: collectionSlug },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetCollectionMeta }
+export { getCollectionMeta }

--- a/src/entities/collection/api/getCollectionMeta/core/useGetCollectionMeta.ts
+++ b/src/entities/collection/api/getCollectionMeta/core/useGetCollectionMeta.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetCollectionMetaResponse } from '../types/IGetCollectionMetaResponse'
+
+import { getCollectionMeta } from './getCollectionMeta'
+
+const useGetCollectionMeta = (
+  collectionSlug: string,
+  options: TUseQueryOptions<typeof getCollectionMeta> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['collection', collectionSlug, 'meta'],
+    queryFn: ({ signal }) =>
+      getCollectionMeta({
+        params: { slug: collectionSlug },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetCollectionMeta }

--- a/src/entities/collection/api/getCollectionMeta/index.ts
+++ b/src/entities/collection/api/getCollectionMeta/index.ts
@@ -1,1 +1,2 @@
-export { useGetCollectionMeta } from './core/getCollectionMeta'
+export { getCollectionMeta } from './core/getCollectionMeta'
+export { useGetCollectionMeta } from './core/useGetCollectionMeta'

--- a/src/entities/collection/api/getUserCollectionAnimesReactionData/core/getUserCollectionAnimesReactionData.ts
+++ b/src/entities/collection/api/getUserCollectionAnimesReactionData/core/getUserCollectionAnimesReactionData.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetUserCollectionAnimesReactionDataResponse } from '../types/IGetUserCollectionAnimesReactionDataResponse'
 
@@ -8,19 +6,4 @@ const getUserCollectionAnimesReactionData = createGetFetcher<
   IGetUserCollectionAnimesReactionDataResponse[]
 >('/collection/{ID}/userAnimeReactions')
 
-const useGetUserCollectionAnimesReactionData = (
-  collectionID: string,
-  options: TUseQueryOptions<typeof getUserCollectionAnimesReactionData> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['collection', collectionID, 'userAnimeReactions'],
-    queryFn: ({ signal }) =>
-      getUserCollectionAnimesReactionData({
-        params: { ID: collectionID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserCollectionAnimesReactionData }
+export { getUserCollectionAnimesReactionData }

--- a/src/entities/collection/api/getUserCollectionAnimesReactionData/core/useGetUserCollectionAnimesReactionData.ts
+++ b/src/entities/collection/api/getUserCollectionAnimesReactionData/core/useGetUserCollectionAnimesReactionData.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetUserCollectionAnimesReactionDataResponse } from '../types/IGetUserCollectionAnimesReactionDataResponse'
+
+import { getUserCollectionAnimesReactionData } from './getUserCollectionAnimesReactionData'
+
+const useGetUserCollectionAnimesReactionData = (
+  collectionID: string,
+  options: TUseQueryOptions<typeof getUserCollectionAnimesReactionData> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['collection', collectionID, 'userAnimeReactions'],
+    queryFn: ({ signal }) =>
+      getUserCollectionAnimesReactionData({
+        params: { ID: collectionID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserCollectionAnimesReactionData }

--- a/src/entities/collection/api/getUserCollectionAnimesReactionData/index.ts
+++ b/src/entities/collection/api/getUserCollectionAnimesReactionData/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserCollectionAnimesReactionData } from './core/getUserCollectionAnimesReactionData'
+export { getUserCollectionAnimesReactionData } from './core/getUserCollectionAnimesReactionData'
+export { useGetUserCollectionAnimesReactionData } from './core/useGetUserCollectionAnimesReactionData'

--- a/src/entities/home/api/getHomeRow/core/getHomeRow.ts
+++ b/src/entities/home/api/getHomeRow/core/getHomeRow.ts
@@ -1,21 +1,7 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetHomeRowResponse } from '../types/IGetHomeRowResponse'
 
 const getHomeRow = createGetFetcher<IGetHomeRowResponse>('/home/row')
 
-const useGetHomeRow = (
-  elementIndex = 1,
-  options: TUseQueryOptions<typeof getHomeRow> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['home', 'row', elementIndex],
-    queryFn: ({ signal }) =>
-      getHomeRow({ query: { elementIndex }, optionsGet: { signal } }),
-  })
-}
-
-export { useGetHomeRow }
+export { getHomeRow }

--- a/src/entities/home/api/getHomeRow/core/useGetHomeRow.ts
+++ b/src/entities/home/api/getHomeRow/core/useGetHomeRow.ts
@@ -1,0 +1,20 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetHomeRowResponse } from '../types/IGetHomeRowResponse'
+
+import { getHomeRow } from './getHomeRow'
+
+const useGetHomeRow = (
+  elementIndex = 1,
+  options: TUseQueryOptions<typeof getHomeRow> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['home', 'row', elementIndex],
+    queryFn: ({ signal }) =>
+      getHomeRow({ query: { elementIndex }, optionsGet: { signal } }),
+  })
+}
+
+export { useGetHomeRow }

--- a/src/entities/home/api/getHomeRow/index.ts
+++ b/src/entities/home/api/getHomeRow/index.ts
@@ -1,1 +1,2 @@
-export { useGetHomeRow } from './core/getHomeRow'
+export { getHomeRow } from './core/getHomeRow'
+export { useGetHomeRow } from './core/useGetHomeRow'

--- a/src/entities/home/api/getInitialHomeData/core/getInitialHomeData.ts
+++ b/src/entities/home/api/getInitialHomeData/core/getInitialHomeData.ts
@@ -1,20 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetInitialHomeDataResponse } from '../types/IGetInitialHomeDataResponse'
 
 const getInitialHomeData =
   createGetFetcher<IGetInitialHomeDataResponse>('/home')
 
-const useGetInitialHomeData = (
-  options: TUseQueryOptions<typeof getInitialHomeData> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['home'],
-    queryFn: ({ signal }) => getInitialHomeData({ optionsGet: { signal } }),
-  })
-}
-
-export { useGetInitialHomeData }
+export { getInitialHomeData }

--- a/src/entities/home/api/getInitialHomeData/core/useGetInitialHomeData.ts
+++ b/src/entities/home/api/getInitialHomeData/core/useGetInitialHomeData.ts
@@ -1,0 +1,18 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetInitialHomeDataResponse } from '../types/IGetInitialHomeDataResponse'
+
+import { getInitialHomeData } from './getInitialHomeData'
+
+const useGetInitialHomeData = (
+  options: TUseQueryOptions<typeof getInitialHomeData> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['home'],
+    queryFn: ({ signal }) => getInitialHomeData({ optionsGet: { signal } }),
+  })
+}
+
+export { useGetInitialHomeData }

--- a/src/entities/home/api/getInitialHomeData/index.ts
+++ b/src/entities/home/api/getInitialHomeData/index.ts
@@ -1,1 +1,2 @@
-export { useGetInitialHomeData } from './core/getInitialHomeData'
+export { getInitialHomeData } from './core/getInitialHomeData'
+export { useGetInitialHomeData } from './core/useGetInitialHomeData'

--- a/src/entities/profile/api/getAdditionalProfileInfo/core/getAdditionalProfileInfo.ts
+++ b/src/entities/profile/api/getAdditionalProfileInfo/core/getAdditionalProfileInfo.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetAdditionalProfileInfoResponse } from '../types/IGetAdditionalProfileInfoResponse'
 
@@ -9,19 +7,4 @@ const getAdditionalProfileInfo =
     '/profile/{ID}/additional',
   )
 
-const useGetAdditionalProfileInfo = (
-  profileID: string,
-  options: TUseQueryOptions<typeof getAdditionalProfileInfo> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['profile', profileID, 'additional'],
-    queryFn: ({ signal }) =>
-      getAdditionalProfileInfo({
-        params: { ID: profileID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetAdditionalProfileInfo }
+export { getAdditionalProfileInfo }

--- a/src/entities/profile/api/getAdditionalProfileInfo/core/useGetAdditionalProfileInfo.ts
+++ b/src/entities/profile/api/getAdditionalProfileInfo/core/useGetAdditionalProfileInfo.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetAdditionalProfileInfoResponse } from '../types/IGetAdditionalProfileInfoResponse'
+
+import { getAdditionalProfileInfo } from './getAdditionalProfileInfo'
+
+const useGetAdditionalProfileInfo = (
+  profileID: string,
+  options: TUseQueryOptions<typeof getAdditionalProfileInfo> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['profile', profileID, 'additional'],
+    queryFn: ({ signal }) =>
+      getAdditionalProfileInfo({
+        params: { ID: profileID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetAdditionalProfileInfo }

--- a/src/entities/profile/api/getAdditionalProfileInfo/index.ts
+++ b/src/entities/profile/api/getAdditionalProfileInfo/index.ts
@@ -1,1 +1,2 @@
-export { useGetAdditionalProfileInfo } from './core/getAdditionalProfileInfo'
+export { getAdditionalProfileInfo } from './core/getAdditionalProfileInfo'
+export { useGetAdditionalProfileInfo } from './core/useGetAdditionalProfileInfo'

--- a/src/entities/profile/api/getProfileMainInfo/core/getProfileMainInfo.ts
+++ b/src/entities/profile/api/getProfileMainInfo/core/getProfileMainInfo.ts
@@ -1,25 +1,8 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetProfileMainInfoResponse } from '../types/IGetProfileMainInfoResponse'
 
 const getProfileMainInfo =
   createGetFetcher<IGetProfileMainInfoResponse>('/profile/{ID}')
 
-const useGetProfileMainInfo = (
-  profileID: string,
-  options: TUseQueryOptions<typeof getProfileMainInfo> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['profile', profileID],
-    queryFn: ({ signal }) =>
-      getProfileMainInfo({
-        params: { ID: profileID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetProfileMainInfo }
+export { getProfileMainInfo }

--- a/src/entities/profile/api/getProfileMainInfo/core/useGetProfileMainInfo.ts
+++ b/src/entities/profile/api/getProfileMainInfo/core/useGetProfileMainInfo.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetProfileMainInfoResponse } from '../types/IGetProfileMainInfoResponse'
+
+import { getProfileMainInfo } from './getProfileMainInfo'
+
+const useGetProfileMainInfo = (
+  profileID: string,
+  options: TUseQueryOptions<typeof getProfileMainInfo> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['profile', profileID],
+    queryFn: ({ signal }) =>
+      getProfileMainInfo({
+        params: { ID: profileID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetProfileMainInfo }

--- a/src/entities/profile/api/getProfileMainInfo/index.ts
+++ b/src/entities/profile/api/getProfileMainInfo/index.ts
@@ -1,1 +1,2 @@
-export { useGetProfileMainInfo } from './core/getProfileMainInfo'
+export { getProfileMainInfo } from './core/getProfileMainInfo'
+export { useGetProfileMainInfo } from './core/useGetProfileMainInfo'

--- a/src/entities/profile/api/getProfileMeta/core/getProfileMeta.ts
+++ b/src/entities/profile/api/getProfileMeta/core/getProfileMeta.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetProfileMetaResponse } from '../types/IGetProfileMetaResponse'
 
@@ -8,19 +6,4 @@ const getProfileMeta = createGetFetcher<IGetProfileMetaResponse>(
   '/profile/{slug}/meta',
 )
 
-const useGetProfileMeta = (
-  profileSlug: string,
-  options: TUseQueryOptions<typeof getProfileMeta> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['profile', profileSlug, 'meta'],
-    queryFn: ({ signal }) =>
-      getProfileMeta({
-        params: { slug: profileSlug },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetProfileMeta }
+export { getProfileMeta }

--- a/src/entities/profile/api/getProfileMeta/core/useGetProfileMeta.ts
+++ b/src/entities/profile/api/getProfileMeta/core/useGetProfileMeta.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetProfileMetaResponse } from '../types/IGetProfileMetaResponse'
+
+import { getProfileMeta } from './getProfileMeta'
+
+const useGetProfileMeta = (
+  profileSlug: string,
+  options: TUseQueryOptions<typeof getProfileMeta> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['profile', profileSlug, 'meta'],
+    queryFn: ({ signal }) =>
+      getProfileMeta({
+        params: { slug: profileSlug },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetProfileMeta }

--- a/src/entities/profile/api/getProfileMeta/index.ts
+++ b/src/entities/profile/api/getProfileMeta/index.ts
@@ -1,1 +1,2 @@
-export { useGetProfileMeta } from './core/getProfileMeta'
+export { getProfileMeta } from './core/getProfileMeta'
+export { useGetProfileMeta } from './core/useGetProfileMeta'

--- a/src/entities/profile/api/getUserAnimeList/core/getUserAnimeList.ts
+++ b/src/entities/profile/api/getUserAnimeList/core/getUserAnimeList.ts
@@ -1,8 +1,4 @@
-import { IUserAnimeReactionModel } from '@entities/anime/types/IUserAnimeReactionModel'
-import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
-import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
 
 import { IGetUserAnimeListResponse } from '../types/IGetUserAnimeListResponse'
 
@@ -10,22 +6,4 @@ const getUserAnimeList = createGetFetcher<IGetUserAnimeListResponse>(
   '/profile/{ID}/animeList',
 )
 
-const useGetUserAnimeList = (
-  profileID: string,
-  listStatus: IUserAnimeReactionModel['status'] = 'added',
-  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
-  options: TUseQueryOptions<typeof getUserAnimeList> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['profile', profileID, 'animeList', listStatus],
-    queryFn: ({ signal }) =>
-      getUserAnimeList({
-        params: { ID: profileID },
-        query: { ...additionalQuery, listStatus },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserAnimeList }
+export { getUserAnimeList }

--- a/src/entities/profile/api/getUserAnimeList/core/useGetUserAnimeList.ts
+++ b/src/entities/profile/api/getUserAnimeList/core/useGetUserAnimeList.ts
@@ -1,0 +1,28 @@
+import { IUserAnimeReactionModel } from '@entities/anime/types/IUserAnimeReactionModel'
+import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
+
+import { IGetUserAnimeListResponse } from '../types/IGetUserAnimeListResponse'
+
+import { getUserAnimeList } from './getUserAnimeList'
+
+const useGetUserAnimeList = (
+  profileID: string,
+  listStatus: IUserAnimeReactionModel['status'] = 'added',
+  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
+  options: TUseQueryOptions<typeof getUserAnimeList> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['profile', profileID, 'animeList', listStatus],
+    queryFn: ({ signal }) =>
+      getUserAnimeList({
+        params: { ID: profileID },
+        query: { ...additionalQuery, listStatus },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserAnimeList }

--- a/src/entities/profile/api/getUserAnimeList/index.ts
+++ b/src/entities/profile/api/getUserAnimeList/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserAnimeList } from './core/getUserAnimeList'
+export { getUserAnimeList } from './core/getUserAnimeList'
+export { useGetUserAnimeList } from './core/useGetUserAnimeList'

--- a/src/entities/profile/api/getUserAnimeReactions/core/getUserAnimeReactions.ts
+++ b/src/entities/profile/api/getUserAnimeReactions/core/getUserAnimeReactions.ts
@@ -1,7 +1,4 @@
-import { IUserAnimeReactionModel } from '@entities/anime/types/IUserAnimeReactionModel'
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetUserAnimeReactionsResponse } from '../types/IGetUserAnimeReactionsResponse'
 
@@ -9,21 +6,4 @@ const getUserAnimeReactions = createGetFetcher<
   IGetUserAnimeReactionsResponse[]
 >('/profile/{ID}/userAnimeReactions')
 
-const useGetUserAnimeReactions = (
-  profileID: string,
-  listStatus: IUserAnimeReactionModel['status'] = 'added',
-  options: TUseQueryOptions<typeof getUserAnimeReactions> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['profile', profileID, 'userAnimeReactions', listStatus],
-    queryFn: ({ signal }) =>
-      getUserAnimeReactions({
-        params: { ID: profileID },
-        query: { listStatus },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserAnimeReactions }
+export { getUserAnimeReactions }

--- a/src/entities/profile/api/getUserAnimeReactions/core/useGetUserAnimeReactions.ts
+++ b/src/entities/profile/api/getUserAnimeReactions/core/useGetUserAnimeReactions.ts
@@ -1,0 +1,26 @@
+import { IUserAnimeReactionModel } from '@entities/anime/types/IUserAnimeReactionModel'
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetUserAnimeReactionsResponse } from '../types/IGetUserAnimeReactionsResponse'
+
+import { getUserAnimeReactions } from './getUserAnimeReactions'
+
+const useGetUserAnimeReactions = (
+  profileID: string,
+  listStatus: IUserAnimeReactionModel['status'] = 'added',
+  options: TUseQueryOptions<typeof getUserAnimeReactions> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['profile', profileID, 'userAnimeReactions', listStatus],
+    queryFn: ({ signal }) =>
+      getUserAnimeReactions({
+        params: { ID: profileID },
+        query: { listStatus },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserAnimeReactions }

--- a/src/entities/profile/api/getUserAnimeReactions/index.ts
+++ b/src/entities/profile/api/getUserAnimeReactions/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserAnimeReactions } from './core/getUserAnimeReactions'
+export { getUserAnimeReactions } from './core/getUserAnimeReactions'
+export { useGetUserAnimeReactions } from './core/useGetUserAnimeReactions'

--- a/src/entities/profile/api/getUserFavoriteAnimeReactions/core/getUserFavoriteAnimeReactions.ts
+++ b/src/entities/profile/api/getUserFavoriteAnimeReactions/core/getUserFavoriteAnimeReactions.ts
@@ -1,6 +1,4 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetUserFavoriteAnimeReactionsResponse } from '../types/IGetUserFavoriteAnimeReactionsResponse'
 
@@ -8,19 +6,4 @@ const getUserFavoriteAnimeReactions = createGetFetcher<
   IGetUserFavoriteAnimeReactionsResponse[]
 >('/profile/{ID}/userFavoriteAnimeReactions')
 
-const useGetUserFavoriteAnimeReactions = (
-  profileID: string,
-  options: TUseQueryOptions<typeof getUserFavoriteAnimeReactions> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['profile', profileID, 'userFavoriteAnimeReactions'],
-    queryFn: ({ signal }) =>
-      getUserFavoriteAnimeReactions({
-        params: { ID: profileID },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserFavoriteAnimeReactions }
+export { getUserFavoriteAnimeReactions }

--- a/src/entities/profile/api/getUserFavoriteAnimeReactions/core/useGetUserFavoriteAnimeReactions.ts
+++ b/src/entities/profile/api/getUserFavoriteAnimeReactions/core/useGetUserFavoriteAnimeReactions.ts
@@ -1,0 +1,23 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetUserFavoriteAnimeReactionsResponse } from '../types/IGetUserFavoriteAnimeReactionsResponse'
+
+import { getUserFavoriteAnimeReactions } from './getUserFavoriteAnimeReactions'
+
+const useGetUserFavoriteAnimeReactions = (
+  profileID: string,
+  options: TUseQueryOptions<typeof getUserFavoriteAnimeReactions> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['profile', profileID, 'userFavoriteAnimeReactions'],
+    queryFn: ({ signal }) =>
+      getUserFavoriteAnimeReactions({
+        params: { ID: profileID },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserFavoriteAnimeReactions }

--- a/src/entities/profile/api/getUserFavoriteAnimeReactions/index.ts
+++ b/src/entities/profile/api/getUserFavoriteAnimeReactions/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserFavoriteAnimeReactions } from './core/getUserFavoriteAnimeReactions'
+export { getUserFavoriteAnimeReactions } from './core/getUserFavoriteAnimeReactions'
+export { useGetUserFavoriteAnimeReactions } from './core/useGetUserFavoriteAnimeReactions'

--- a/src/entities/profile/api/getUserFavoriteAnimes/core/getUserFavoriteAnimes.ts
+++ b/src/entities/profile/api/getUserFavoriteAnimes/core/getUserFavoriteAnimes.ts
@@ -1,7 +1,4 @@
-import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
-import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
 
 import { IGetUserFavoriteAnimesResponse } from '../types/IGetUserFavoriteAnimesResponse'
 
@@ -9,21 +6,4 @@ const getUserFavoriteAnimes = createGetFetcher<IGetUserFavoriteAnimesResponse>(
   '/profile/{ID}/favoriteAnimes',
 )
 
-const useGetUserFavoriteAnimes = (
-  profileID: string,
-  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
-  options: TUseQueryOptions<typeof getUserFavoriteAnimes> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['profile', profileID, 'favoriteAnimes'],
-    queryFn: ({ signal }) =>
-      getUserFavoriteAnimes({
-        params: { ID: profileID },
-        query: { ...additionalQuery },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetUserFavoriteAnimes }
+export { getUserFavoriteAnimes }

--- a/src/entities/profile/api/getUserFavoriteAnimes/core/useGetUserFavoriteAnimes.ts
+++ b/src/entities/profile/api/getUserFavoriteAnimes/core/useGetUserFavoriteAnimes.ts
@@ -1,0 +1,26 @@
+import { IPaginationQuery, TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { IAnimeFIltersAndSort } from '@entities/anime/types/IAnimeFIltersAndSort'
+
+import { IGetUserFavoriteAnimesResponse } from '../types/IGetUserFavoriteAnimesResponse'
+
+import { getUserFavoriteAnimes } from './getUserFavoriteAnimes'
+
+const useGetUserFavoriteAnimes = (
+  profileID: string,
+  additionalQuery: IAnimeFIltersAndSort & IPaginationQuery = {},
+  options: TUseQueryOptions<typeof getUserFavoriteAnimes> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['profile', profileID, 'favoriteAnimes'],
+    queryFn: ({ signal }) =>
+      getUserFavoriteAnimes({
+        params: { ID: profileID },
+        query: { ...additionalQuery },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetUserFavoriteAnimes }

--- a/src/entities/profile/api/getUserFavoriteAnimes/index.ts
+++ b/src/entities/profile/api/getUserFavoriteAnimes/index.ts
@@ -1,1 +1,2 @@
-export { useGetUserFavoriteAnimes } from './core/getUserFavoriteAnimes'
+export { getUserFavoriteAnimes } from './core/getUserFavoriteAnimes'
+export { useGetUserFavoriteAnimes } from './core/useGetUserFavoriteAnimes'

--- a/src/entities/search/api/getSearch/core/getSearch.ts
+++ b/src/entities/search/api/getSearch/core/getSearch.ts
@@ -1,25 +1,7 @@
-import { TUseQueryOptions } from '@shared/types'
 import { createGetFetcher } from '@shared/utils/functions'
-import { useQuery } from '@tanstack/react-query'
 
 import { IGetSearchResponse } from '../types/IGetSearchResponse'
 
 const getSearch = createGetFetcher<IGetSearchResponse>('/search')
 
-const useGetSearch = (
-  search: string,
-  searchType: 'Anime' | 'Collection' | 'DubClub' | 'User',
-  options: TUseQueryOptions<typeof getSearch> = {},
-) => {
-  return useQuery({
-    ...options,
-    queryKey: ['search', search, searchType],
-    queryFn: ({ signal }) =>
-      getSearch({
-        query: { search, searchType },
-        optionsGet: { signal },
-      }),
-  })
-}
-
-export { useGetSearch }
+export { getSearch }

--- a/src/entities/search/api/getSearch/core/useGetSearch.ts
+++ b/src/entities/search/api/getSearch/core/useGetSearch.ts
@@ -1,0 +1,24 @@
+import { TUseQueryOptions } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+
+import { IGetSearchResponse } from '../types/IGetSearchResponse'
+
+import { getSearch } from './getSearch'
+
+const useGetSearch = (
+  search: string,
+  searchType: 'Anime' | 'Collection' | 'DubClub' | 'User',
+  options: TUseQueryOptions<typeof getSearch> = {},
+) => {
+  return useQuery({
+    ...options,
+    queryKey: ['search', search, searchType],
+    queryFn: ({ signal }) =>
+      getSearch({
+        query: { search, searchType },
+        optionsGet: { signal },
+      }),
+  })
+}
+
+export { useGetSearch }

--- a/src/entities/search/api/getSearch/index.ts
+++ b/src/entities/search/api/getSearch/index.ts
@@ -1,1 +1,2 @@
-export { useGetSearch } from './core/getSearch'
+export { getSearch } from './core/getSearch'
+export { useGetSearch } from './core/useGetSearch'


### PR DESCRIPTION
## Summary
- разделены GET fetcher и хук во всех сущностях
- обновлены индексные файлы для реэкспорта fetcher и хука

## Testing
- `pnpm lint:fix` *(fails: Cannot find module '@entities/auth/api/getWhoami')*


------
https://chatgpt.com/codex/tasks/task_e_68ab0bfcdc8c8332a003d865654889c9