### PR TITLE
Разделение fetcher и хуков для мутаций

### DIFF
--- a/src/entities/account/api/confirmCodeAndUpdatePassword/core/confirmCodeAndUpdatePassword.ts
+++ b/src/entities/account/api/confirmCodeAndUpdatePassword/core/confirmCodeAndUpdatePassword.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { LockIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { IConfirmCodeAndUpdatePasswordBody } from '../types/IConfirmCodeAndUpdatePasswordBody'
 
@@ -14,26 +10,6 @@ const confirmCodeAndUpdatePasswordAdapter = (
   body: IConfirmCodeAndUpdatePasswordBody,
 ) => confirmCodeAndUpdatePassword({ optionsPost: { body } })
 
-const useConfirmCodeAndUpdatePassword = (
-  options: TUseMutationOptions<typeof confirmCodeAndUpdatePasswordAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: confirmCodeAndUpdatePasswordAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({ message: 'Пароль успешно изменён', Icon: LockIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
+export {
+  confirmCodeAndUpdatePasswordAdapter as confirmCodeAndUpdatePassword,
 }
-
-export { useConfirmCodeAndUpdatePassword }

--- a/src/entities/account/api/confirmCodeAndUpdatePassword/core/useConfirmCodeAndUpdatePassword.ts
+++ b/src/entities/account/api/confirmCodeAndUpdatePassword/core/useConfirmCodeAndUpdatePassword.ts
@@ -1,0 +1,30 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { LockIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { confirmCodeAndUpdatePassword } from './confirmCodeAndUpdatePassword'
+
+const useConfirmCodeAndUpdatePassword = (
+  options: TUseMutationOptions<typeof confirmCodeAndUpdatePassword> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: confirmCodeAndUpdatePassword,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({ message: 'Пароль успешно изменён', Icon: LockIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useConfirmCodeAndUpdatePassword }

--- a/src/entities/account/api/confirmCodeAndUpdatePassword/index.ts
+++ b/src/entities/account/api/confirmCodeAndUpdatePassword/index.ts
@@ -1,1 +1,2 @@
-export { useConfirmCodeAndUpdatePassword } from './core/confirmCodeAndUpdatePassword'
+export { confirmCodeAndUpdatePassword } from './core/confirmCodeAndUpdatePassword'
+export { useConfirmCodeAndUpdatePassword } from './core/useConfirmCodeAndUpdatePassword'

--- a/src/entities/account/api/sendToEmailResetPassword/core/sendToEmailResetPassword.ts
+++ b/src/entities/account/api/sendToEmailResetPassword/core/sendToEmailResetPassword.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { MailIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { ISendToEmailResetPasswordBody } from '../types/ISendToEmailResetPasswordBody'
 
@@ -10,32 +6,8 @@ const sendToEmailResetPassword = createPostFetcher(
   '/account/password/reset',
   'POST',
 )
-const sendToEmailResetPasswordAdapter = (body: ISendToEmailResetPasswordBody) =>
-  sendToEmailResetPassword({ optionsPost: { body } })
+const sendToEmailResetPasswordAdapter = (
+  body: ISendToEmailResetPasswordBody,
+) => sendToEmailResetPassword({ optionsPost: { body } })
 
-const useSendToEmailResetPassword = (
-  options: TUseMutationOptions<typeof sendToEmailResetPasswordAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: sendToEmailResetPasswordAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({
-        message: 'Заявка на сброс пароля отправлена',
-        Icon: MailIcon,
-      })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useSendToEmailResetPassword }
+export { sendToEmailResetPasswordAdapter as sendToEmailResetPassword }

--- a/src/entities/account/api/sendToEmailResetPassword/core/useSendToEmailResetPassword.ts
+++ b/src/entities/account/api/sendToEmailResetPassword/core/useSendToEmailResetPassword.ts
@@ -1,0 +1,33 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { MailIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { sendToEmailResetPassword } from './sendToEmailResetPassword'
+
+const useSendToEmailResetPassword = (
+  options: TUseMutationOptions<typeof sendToEmailResetPassword> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: sendToEmailResetPassword,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({
+        message: 'Заявка на сброс пароля отправлена',
+        Icon: MailIcon,
+      })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useSendToEmailResetPassword }

--- a/src/entities/account/api/sendToEmailResetPassword/index.ts
+++ b/src/entities/account/api/sendToEmailResetPassword/index.ts
@@ -1,1 +1,2 @@
-export { useSendToEmailResetPassword } from './core/sendToEmailResetPassword'
+export { sendToEmailResetPassword } from './core/sendToEmailResetPassword'
+export { useSendToEmailResetPassword } from './core/useSendToEmailResetPassword'

--- a/src/entities/account/api/updateEmail/core/updateEmail.ts
+++ b/src/entities/account/api/updateEmail/core/updateEmail.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { IUpdateEmailBody } from '../types/IUpdateEmailBody'
 
@@ -10,26 +6,4 @@ const updateEmail = createPostFetcher('/account/email', 'PATCH')
 const updateEmailAdapter = (body: IUpdateEmailBody) =>
   updateEmail({ optionsPost: { body } })
 
-const useUpdateEmail = (
-  options: TUseMutationOptions<typeof updateEmailAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: updateEmailAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({ message: '', Icon: UserIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useUpdateEmail }
+export { updateEmailAdapter as updateEmail }

--- a/src/entities/account/api/updateEmail/core/useUpdateEmail.ts
+++ b/src/entities/account/api/updateEmail/core/useUpdateEmail.ts
@@ -1,0 +1,30 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { updateEmail } from './updateEmail'
+
+const useUpdateEmail = (
+  options: TUseMutationOptions<typeof updateEmail> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: updateEmail,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({ message: '', Icon: UserIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useUpdateEmail }

--- a/src/entities/account/api/updateEmail/index.ts
+++ b/src/entities/account/api/updateEmail/index.ts
@@ -1,1 +1,2 @@
-export { useUpdateEmail } from './core/updateEmail'
+export { updateEmail } from './core/updateEmail'
+export { useUpdateEmail } from './core/useUpdateEmail'

--- a/src/entities/account/api/updateNickname/core/updateNickname.ts
+++ b/src/entities/account/api/updateNickname/core/updateNickname.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { IUpdateNicknameBody } from '../types/IUpdateNicknameBody'
 
@@ -10,27 +6,4 @@ const updateNickname = createPostFetcher('/account/nickname', 'PATCH')
 const updateNicknameAdapter = (body: IUpdateNicknameBody) =>
   updateNickname({ optionsPost: { body } })
 
-const useUpdateNickname = (
-  options: TUseMutationOptions<typeof updateNicknameAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: updateNicknameAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-      ])
-
-      successToast({ message: 'Nickname успешно изменён', Icon: UserIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useUpdateNickname }
+export { updateNicknameAdapter as updateNickname }

--- a/src/entities/account/api/updateNickname/core/useUpdateNickname.ts
+++ b/src/entities/account/api/updateNickname/core/useUpdateNickname.ts
@@ -1,0 +1,31 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { updateNickname } from './updateNickname'
+
+const useUpdateNickname = (
+  options: TUseMutationOptions<typeof updateNickname> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: updateNickname,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+      ])
+
+      successToast({ message: 'Nickname успешно изменён', Icon: UserIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useUpdateNickname }

--- a/src/entities/account/api/updateNickname/index.ts
+++ b/src/entities/account/api/updateNickname/index.ts
@@ -1,1 +1,2 @@
-export { useUpdateNickname } from './core/updateNickname'
+export { updateNickname } from './core/updateNickname'
+export { useUpdateNickname } from './core/useUpdateNickname'

--- a/src/entities/account/api/updatePassword/core/updatePassword.ts
+++ b/src/entities/account/api/updatePassword/core/updatePassword.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { LockIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { IUpdatePasswordBody } from '../types/IUpdatePasswordBody'
 
@@ -10,26 +6,4 @@ const updatePassword = createPostFetcher('/account/password', 'PATCH')
 const updatePasswordAdapter = (body: IUpdatePasswordBody) =>
   updatePassword({ optionsPost: { body } })
 
-const useUpdatePassword = (
-  options: TUseMutationOptions<typeof updatePasswordAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: updatePasswordAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({ message: 'Пароль успешно изменён', Icon: LockIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useUpdatePassword }
+export { updatePasswordAdapter as updatePassword }

--- a/src/entities/account/api/updatePassword/core/useUpdatePassword.ts
+++ b/src/entities/account/api/updatePassword/core/useUpdatePassword.ts
@@ -1,0 +1,30 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { LockIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { updatePassword } from './updatePassword'
+
+const useUpdatePassword = (
+  options: TUseMutationOptions<typeof updatePassword> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: updatePassword,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({ message: 'Пароль успешно изменён', Icon: LockIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useUpdatePassword }

--- a/src/entities/account/api/updatePassword/index.ts
+++ b/src/entities/account/api/updatePassword/index.ts
@@ -1,1 +1,2 @@
-export { useUpdatePassword } from './core/updatePassword'
+export { updatePassword } from './core/updatePassword'
+export { useUpdatePassword } from './core/useUpdatePassword'

--- a/src/entities/account/api/updateUsername/core/updateUsername.ts
+++ b/src/entities/account/api/updateUsername/core/updateUsername.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { IUpdateUsernameBody } from '../types/IUpdateUsernameBody'
 
@@ -10,27 +6,4 @@ const updateUsername = createPostFetcher('/account/username', 'PATCH')
 const updateUsernameAdapter = (body: IUpdateUsernameBody) =>
   updateUsername({ optionsPost: { body } })
 
-const useUpdateUsername = (
-  options: TUseMutationOptions<typeof updateUsernameAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: updateUsernameAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-      ])
-
-      successToast({ message: 'Username успешно изменён', Icon: UserIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useUpdateUsername }
+export { updateUsernameAdapter as updateUsername }

--- a/src/entities/account/api/updateUsername/core/useUpdateUsername.ts
+++ b/src/entities/account/api/updateUsername/core/useUpdateUsername.ts
@@ -1,0 +1,31 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { updateUsername } from './updateUsername'
+
+const useUpdateUsername = (
+  options: TUseMutationOptions<typeof updateUsername> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: updateUsername,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+      ])
+
+      successToast({ message: 'Username успешно изменён', Icon: UserIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useUpdateUsername }

--- a/src/entities/account/api/updateUsername/index.ts
+++ b/src/entities/account/api/updateUsername/index.ts
@@ -1,1 +1,2 @@
-export { useUpdateUsername } from './core/updateUsername'
+export { updateUsername } from './core/updateUsername'
+export { useUpdateUsername } from './core/useUpdateUsername'

--- a/src/entities/anime/api/deleteAnimeUserReaction/core/deleteAnimeUserReaction.ts
+++ b/src/entities/anime/api/deleteAnimeUserReaction/core/deleteAnimeUserReaction.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { TrashIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 const deleteAnimeUserReaction = createPostFetcher(
   '/anime/{ID}/userReaction',
@@ -11,32 +7,4 @@ const deleteAnimeUserReaction = createPostFetcher(
 const deleteAnimeUserReactionAdapter = ({ animeID }: { animeID: string }) =>
   deleteAnimeUserReaction({ params: { ID: animeID } })
 
-const useDeleteAnimeUserReaction = (
-  options: TUseMutationOptions<typeof deleteAnimeUserReactionAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: deleteAnimeUserReactionAdapter,
-    onSuccess: async ({ query }) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ['anime', query?.ID],
-          exact: false,
-        }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
-      ])
-
-      successToast({ message: 'Статус аниме в списке удален', Icon: TrashIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useDeleteAnimeUserReaction }
+export { deleteAnimeUserReactionAdapter as deleteAnimeUserReaction }

--- a/src/entities/anime/api/deleteAnimeUserReaction/core/useDeleteAnimeUserReaction.ts
+++ b/src/entities/anime/api/deleteAnimeUserReaction/core/useDeleteAnimeUserReaction.ts
@@ -1,0 +1,36 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { TrashIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { deleteAnimeUserReaction } from './deleteAnimeUserReaction'
+
+const useDeleteAnimeUserReaction = (
+  options: TUseMutationOptions<typeof deleteAnimeUserReaction> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: deleteAnimeUserReaction,
+    onSuccess: async ({ query }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['anime', query?.ID],
+          exact: false,
+        }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
+      ])
+
+      successToast({ message: 'Статус аниме в списке удален', Icon: TrashIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useDeleteAnimeUserReaction }

--- a/src/entities/anime/api/deleteAnimeUserReaction/index.ts
+++ b/src/entities/anime/api/deleteAnimeUserReaction/index.ts
@@ -1,1 +1,2 @@
-export { useDeleteAnimeUserReaction } from './core/deleteAnimeUserReaction'
+export { deleteAnimeUserReaction } from './core/deleteAnimeUserReaction'
+export { useDeleteAnimeUserReaction } from './core/useDeleteAnimeUserReaction'

--- a/src/entities/anime/api/patchEpisodeProgress/core/patchEpisodeProgress.ts
+++ b/src/entities/anime/api/patchEpisodeProgress/core/patchEpisodeProgress.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { PlayIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { IPatchEpisodeProgressBody } from '../types/IPatchEpisodeProgressBody'
 
@@ -15,25 +11,4 @@ const patchEpisodeProgressAdapter = ({
   episodeID: string
 }) => patchEpisodeProgress({ params: { ID: episodeID }, optionsPost: { body } })
 
-const usePatchEpisodeProgress = (
-  options: TUseMutationOptions<typeof patchEpisodeProgressAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: patchEpisodeProgressAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-      ])
-
-      successToast({ message: 'Прогресс эпизода обновлен', Icon: PlayIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { usePatchEpisodeProgress }
+export { patchEpisodeProgressAdapter as patchEpisodeProgress }

--- a/src/entities/anime/api/patchEpisodeProgress/core/usePatchEpisodeProgress.ts
+++ b/src/entities/anime/api/patchEpisodeProgress/core/usePatchEpisodeProgress.ts
@@ -1,0 +1,29 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { PlayIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { patchEpisodeProgress } from './patchEpisodeProgress'
+
+const usePatchEpisodeProgress = (
+  options: TUseMutationOptions<typeof patchEpisodeProgress> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: patchEpisodeProgress,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+      ])
+
+      successToast({ message: 'Прогресс эпизода обновлен', Icon: PlayIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { usePatchEpisodeProgress }

--- a/src/entities/anime/api/patchEpisodeProgress/index.ts
+++ b/src/entities/anime/api/patchEpisodeProgress/index.ts
@@ -1,1 +1,2 @@
-export { usePatchEpisodeProgress } from './core/patchEpisodeProgress'
+export { patchEpisodeProgress } from './core/patchEpisodeProgress'
+export { usePatchEpisodeProgress } from './core/usePatchEpisodeProgress'

--- a/src/entities/anime/api/setAnimeFavorite/core/setAnimeFavorite.ts
+++ b/src/entities/anime/api/setAnimeFavorite/core/setAnimeFavorite.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { StarIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { ISetAnimeFavoriteBody } from '../types/ISetAnimeFavoriteBody'
 
@@ -15,32 +11,4 @@ const setAnimeFavoriteAdapter = ({
   body: ISetAnimeFavoriteBody
 }) => setAnimeFavorite({ params: { ID: animeID }, optionsPost: { body } })
 
-const useSetAnimeFavorite = (
-  options: TUseMutationOptions<typeof setAnimeFavoriteAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: setAnimeFavoriteAdapter,
-    onSuccess: async ({ query }) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ['anime', query?.ID],
-          exact: false,
-        }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
-      ])
-
-      successToast({ message: 'Аниме добавлено в избранное', Icon: StarIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useSetAnimeFavorite }
+export { setAnimeFavoriteAdapter as setAnimeFavorite }

--- a/src/entities/anime/api/setAnimeFavorite/core/useSetAnimeFavorite.ts
+++ b/src/entities/anime/api/setAnimeFavorite/core/useSetAnimeFavorite.ts
@@ -1,0 +1,36 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { StarIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { setAnimeFavorite } from './setAnimeFavorite'
+
+const useSetAnimeFavorite = (
+  options: TUseMutationOptions<typeof setAnimeFavorite> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: setAnimeFavorite,
+    onSuccess: async ({ query }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['anime', query?.ID],
+          exact: false,
+        }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
+      ])
+
+      successToast({ message: 'Аниме добавлено в избранное', Icon: StarIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useSetAnimeFavorite }

--- a/src/entities/anime/api/setAnimeFavorite/index.ts
+++ b/src/entities/anime/api/setAnimeFavorite/index.ts
@@ -1,1 +1,2 @@
-export { useSetAnimeFavorite } from './core/setAnimeFavorite'
+export { setAnimeFavorite } from './core/setAnimeFavorite'
+export { useSetAnimeFavorite } from './core/useSetAnimeFavorite'

--- a/src/entities/anime/api/setAnimeScore/core/setAnimeScore.ts
+++ b/src/entities/anime/api/setAnimeScore/core/setAnimeScore.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { StarIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { ISetAnimeScoreBody } from '../types/ISetAnimeScoreBody'
 
@@ -15,35 +11,4 @@ const setAnimeScoreAdapter = ({
   body: ISetAnimeScoreBody
 }) => setAnimeScore({ params: { ID: animeID }, optionsPost: { body } })
 
-const useSetAnimeScore = (
-  options: TUseMutationOptions<typeof setAnimeScoreAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: setAnimeScoreAdapter,
-    onSuccess: async ({ query }) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ['anime', query?.ID],
-          exact: false,
-        }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
-      ])
-
-      successToast({
-        message: 'Оценка аниме обновлена',
-        Icon: StarIcon,
-      })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useSetAnimeScore }
+export { setAnimeScoreAdapter as setAnimeScore }

--- a/src/entities/anime/api/setAnimeScore/core/useSetAnimeScore.ts
+++ b/src/entities/anime/api/setAnimeScore/core/useSetAnimeScore.ts
@@ -1,0 +1,39 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { StarIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { setAnimeScore } from './setAnimeScore'
+
+const useSetAnimeScore = (
+  options: TUseMutationOptions<typeof setAnimeScore> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: setAnimeScore,
+    onSuccess: async ({ query }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['anime', query?.ID],
+          exact: false,
+        }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
+      ])
+
+      successToast({
+        message: 'Оценка аниме обновлена',
+        Icon: StarIcon,
+      })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useSetAnimeScore }

--- a/src/entities/anime/api/setAnimeScore/index.ts
+++ b/src/entities/anime/api/setAnimeScore/index.ts
@@ -1,1 +1,2 @@
-export { useSetAnimeScore } from './core/setAnimeScore'
+export { setAnimeScore } from './core/setAnimeScore'
+export { useSetAnimeScore } from './core/useSetAnimeScore'

--- a/src/entities/anime/api/setAnimeUserReactionData/core/setAnimeUserReactionData.ts
+++ b/src/entities/anime/api/setAnimeUserReactionData/core/setAnimeUserReactionData.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { CassetteTapeIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { ISetAnimeUserReactionDataBody } from '../types/ISetAnimeUserReactionDataBody'
 
@@ -19,35 +15,4 @@ const setAnimeUserReactionDataAdapter = ({
 }) =>
   setAnimeUserReactionData({ params: { ID: animeID }, optionsPost: { body } })
 
-const useSetAnimeUserReactionData = (
-  options: TUseMutationOptions<typeof setAnimeUserReactionDataAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: setAnimeUserReactionDataAdapter,
-    onSuccess: async ({ query }) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ['anime', query?.ID],
-          exact: false,
-        }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
-      ])
-
-      successToast({
-        message: 'Рeакция на аниме обновлена',
-        Icon: CassetteTapeIcon,
-      })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useSetAnimeUserReactionData }
+export { setAnimeUserReactionDataAdapter as setAnimeUserReactionData }

--- a/src/entities/anime/api/setAnimeUserReactionData/core/useSetAnimeUserReactionData.ts
+++ b/src/entities/anime/api/setAnimeUserReactionData/core/useSetAnimeUserReactionData.ts
@@ -1,0 +1,39 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { CassetteTapeIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { setAnimeUserReactionData } from './setAnimeUserReactionData'
+
+const useSetAnimeUserReactionData = (
+  options: TUseMutationOptions<typeof setAnimeUserReactionData> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: setAnimeUserReactionData,
+    onSuccess: async ({ query }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['anime', query?.ID],
+          exact: false,
+        }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
+      ])
+
+      successToast({
+        message: 'Рeакция на аниме обновлена',
+        Icon: CassetteTapeIcon,
+      })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useSetAnimeUserReactionData }

--- a/src/entities/anime/api/setAnimeUserReactionData/index.ts
+++ b/src/entities/anime/api/setAnimeUserReactionData/index.ts
@@ -1,1 +1,2 @@
-export { useSetAnimeUserReactionData } from './core/setAnimeUserReactionData'
+export { setAnimeUserReactionData } from './core/setAnimeUserReactionData'
+export { useSetAnimeUserReactionData } from './core/useSetAnimeUserReactionData'

--- a/src/entities/anime/api/setAnimeUserStatus/core/setAnimeUserStatus.ts
+++ b/src/entities/anime/api/setAnimeUserStatus/core/setAnimeUserStatus.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { CassetteTapeIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { ISetAnimeUserStatusBody } from '../types/ISetAnimeUserStatusBody'
 
@@ -15,35 +11,4 @@ const setAnimeUserStatusAdapter = ({
   body: ISetAnimeUserStatusBody
 }) => setAnimeUserStatus({ params: { ID: animeID }, optionsPost: { body } })
 
-const useSetAnimeUserStatus = (
-  options: TUseMutationOptions<typeof setAnimeUserStatusAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: setAnimeUserStatusAdapter,
-    onSuccess: async ({ query }) => {
-      await Promise.all([
-        queryClient.invalidateQueries({
-          queryKey: ['anime', query?.ID],
-          exact: false,
-        }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
-      ])
-
-      successToast({
-        message: 'Аниме добавлено в список',
-        Icon: CassetteTapeIcon,
-      })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useSetAnimeUserStatus }
+export { setAnimeUserStatusAdapter as setAnimeUserStatus }

--- a/src/entities/anime/api/setAnimeUserStatus/core/useSetAnimeUserStatus.ts
+++ b/src/entities/anime/api/setAnimeUserStatus/core/useSetAnimeUserStatus.ts
@@ -1,0 +1,39 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { CassetteTapeIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { setAnimeUserStatus } from './setAnimeUserStatus'
+
+const useSetAnimeUserStatus = (
+  options: TUseMutationOptions<typeof setAnimeUserStatus> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: setAnimeUserStatus,
+    onSuccess: async ({ query }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ['anime', query?.ID],
+          exact: false,
+        }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
+      ])
+
+      successToast({
+        message: 'Аниме добавлено в список',
+        Icon: CassetteTapeIcon,
+      })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useSetAnimeUserStatus }

--- a/src/entities/anime/api/setAnimeUserStatus/index.ts
+++ b/src/entities/anime/api/setAnimeUserStatus/index.ts
@@ -1,1 +1,2 @@
-export { useSetAnimeUserStatus } from './core/setAnimeUserStatus'
+export { setAnimeUserStatus } from './core/setAnimeUserStatus'
+export { useSetAnimeUserStatus } from './core/useSetAnimeUserStatus'

--- a/src/entities/apps/api/addAnimeToSkipList/core/addAnimeToSkipList.ts
+++ b/src/entities/apps/api/addAnimeToSkipList/core/addAnimeToSkipList.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { successToast, errorToast } from '@shared/utils/toast'
-import { StarOffIcon } from '@shared/icons'
 
 import { IAddAnimeToSkipListBody } from '../types/IAddAnimeToSkipListBody'
 
@@ -10,30 +6,4 @@ const addAnimeToSkipList = createPostFetcher('/aniPick/skipList', 'POST')
 const addAnimeToSkipListAdapter = (body: IAddAnimeToSkipListBody) =>
   addAnimeToSkipList({ optionsPost: { body } })
 
-const useAddAnimeToSkipList = (
-  options: TUseMutationOptions<typeof addAnimeToSkipListAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: addAnimeToSkipListAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
-        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
-      ])
-
-      successToast({
-        message: 'Аниме добавлено в пропущенное',
-        Icon: StarOffIcon,
-      })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useAddAnimeToSkipList }
+export { addAnimeToSkipListAdapter as addAnimeToSkipList }

--- a/src/entities/apps/api/addAnimeToSkipList/core/useAddAnimeToSkipList.ts
+++ b/src/entities/apps/api/addAnimeToSkipList/core/useAddAnimeToSkipList.ts
@@ -1,0 +1,34 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { successToast, errorToast } from '@shared/utils/toast'
+import { StarOffIcon } from '@shared/icons'
+
+import { addAnimeToSkipList } from './addAnimeToSkipList'
+
+const useAddAnimeToSkipList = (
+  options: TUseMutationOptions<typeof addAnimeToSkipList> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: addAnimeToSkipList,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['aniPick'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniJudge'] }),
+        queryClient.invalidateQueries({ queryKey: ['aniBattle'] }),
+      ])
+
+      successToast({
+        message: 'Аниме добавлено в пропущенное',
+        Icon: StarOffIcon,
+      })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useAddAnimeToSkipList }

--- a/src/entities/apps/api/addAnimeToSkipList/index.ts
+++ b/src/entities/apps/api/addAnimeToSkipList/index.ts
@@ -1,1 +1,2 @@
-export { useAddAnimeToSkipList } from './core/addAnimeToSkipList'
+export { addAnimeToSkipList } from './core/addAnimeToSkipList'
+export { useAddAnimeToSkipList } from './core/useAddAnimeToSkipList'

--- a/src/entities/auth/api/createNewAccount/core/createNewAccount.ts
+++ b/src/entities/auth/api/createNewAccount/core/createNewAccount.ts
@@ -1,32 +1,6 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 const createNewAccount = createPostFetcher('/auth/temporary', 'POST')
 const createNewAccountAdapter = () => createNewAccount()
 
-const useCreateNewAccount = (
-  options: TUseMutationOptions<typeof createNewAccountAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: createNewAccountAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({ message: 'Вы успешно создали аккаунт', Icon: UserIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useCreateNewAccount }
+export { createNewAccountAdapter as createNewAccount }

--- a/src/entities/auth/api/createNewAccount/core/useCreateNewAccount.ts
+++ b/src/entities/auth/api/createNewAccount/core/useCreateNewAccount.ts
@@ -1,0 +1,30 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { createNewAccount } from './createNewAccount'
+
+const useCreateNewAccount = (
+  options: TUseMutationOptions<typeof createNewAccount> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: createNewAccount,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({ message: 'Вы успешно создали аккаунт', Icon: UserIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useCreateNewAccount }

--- a/src/entities/auth/api/createNewAccount/index.ts
+++ b/src/entities/auth/api/createNewAccount/index.ts
@@ -1,1 +1,2 @@
-export { useCreateNewAccount } from './core/createNewAccount'
+export { createNewAccount } from './core/createNewAccount'
+export { useCreateNewAccount } from './core/useCreateNewAccount'

--- a/src/entities/auth/api/createNewTemporaryCode/core/createNewTemporaryCode.ts
+++ b/src/entities/auth/api/createNewTemporaryCode/core/createNewTemporaryCode.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 const createNewTemporaryCode = createPostFetcher(
   '/auth/temporary/code',
@@ -10,29 +6,4 @@ const createNewTemporaryCode = createPostFetcher(
 )
 const createNewTemporaryCodeAdapter = () => createNewTemporaryCode()
 
-const useCreateNewTemporaryCode = (
-  options: TUseMutationOptions<typeof createNewTemporaryCodeAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: createNewTemporaryCodeAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({
-        message: 'Вы успешно создали новый временный код',
-        Icon: UserIcon,
-      })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useCreateNewTemporaryCode }
+export { createNewTemporaryCodeAdapter as createNewTemporaryCode }

--- a/src/entities/auth/api/createNewTemporaryCode/core/useCreateNewTemporaryCode.ts
+++ b/src/entities/auth/api/createNewTemporaryCode/core/useCreateNewTemporaryCode.ts
@@ -1,0 +1,33 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { createNewTemporaryCode } from './createNewTemporaryCode'
+
+const useCreateNewTemporaryCode = (
+  options: TUseMutationOptions<typeof createNewTemporaryCode> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: createNewTemporaryCode,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({
+        message: 'Вы успешно создали новый временный код',
+        Icon: UserIcon,
+      })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useCreateNewTemporaryCode }

--- a/src/entities/auth/api/createNewTemporaryCode/index.ts
+++ b/src/entities/auth/api/createNewTemporaryCode/index.ts
@@ -1,1 +1,2 @@
-export { useCreateNewTemporaryCode } from './core/createNewTemporaryCode'
+export { createNewTemporaryCode } from './core/createNewTemporaryCode'
+export { useCreateNewTemporaryCode } from './core/useCreateNewTemporaryCode'

--- a/src/entities/auth/api/deleteSession/core/deleteSession.ts
+++ b/src/entities/auth/api/deleteSession/core/deleteSession.ts
@@ -1,36 +1,7 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { KeyRoundIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 const deleteSession = createPostFetcher('/auth/session/delete', 'DELETE')
 const deleteSessionAdapter = () =>
   deleteSession({ optionsPost: { tokenType: 'refreshToken' } })
 
-const useDeleteSession = (
-  options: TUseMutationOptions<typeof deleteSessionAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: deleteSessionAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({
-        message: 'Вы успешно удалили сессию',
-        Icon: KeyRoundIcon,
-      })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useDeleteSession }
+export { deleteSessionAdapter as deleteSession }

--- a/src/entities/auth/api/deleteSession/core/useDeleteSession.ts
+++ b/src/entities/auth/api/deleteSession/core/useDeleteSession.ts
@@ -1,0 +1,33 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { KeyRoundIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { deleteSession } from './deleteSession'
+
+const useDeleteSession = (
+  options: TUseMutationOptions<typeof deleteSession> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: deleteSession,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({
+        message: 'Вы успешно удалили сессию',
+        Icon: KeyRoundIcon,
+      })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useDeleteSession }

--- a/src/entities/auth/api/deleteSession/index.ts
+++ b/src/entities/auth/api/deleteSession/index.ts
@@ -1,1 +1,2 @@
-export { useDeleteSession } from './core/deleteSession'
+export { deleteSession } from './core/deleteSession'
+export { useDeleteSession } from './core/useDeleteSession'

--- a/src/entities/auth/api/loginByPassword/core/loginByPassword.ts
+++ b/src/entities/auth/api/loginByPassword/core/loginByPassword.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { ILoginByPasswordBody } from '../types/ILoginByPasswordBody'
 
@@ -10,26 +6,4 @@ const loginByPassword = createPostFetcher('/auth/login', 'POST')
 const loginByPasswordAdapter = (body: ILoginByPasswordBody) =>
   loginByPassword({ optionsPost: { body } })
 
-const useLoginByPassword = (
-  options: TUseMutationOptions<typeof loginByPasswordAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: loginByPasswordAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({ message: 'Вы вошли в систему', Icon: UserIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useLoginByPassword }
+export { loginByPasswordAdapter as loginByPassword }

--- a/src/entities/auth/api/loginByPassword/core/useLoginByPassword.ts
+++ b/src/entities/auth/api/loginByPassword/core/useLoginByPassword.ts
@@ -1,0 +1,30 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { loginByPassword } from './loginByPassword'
+
+const useLoginByPassword = (
+  options: TUseMutationOptions<typeof loginByPassword> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: loginByPassword,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({ message: 'Вы вошли в систему', Icon: UserIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useLoginByPassword }

--- a/src/entities/auth/api/loginByPassword/index.ts
+++ b/src/entities/auth/api/loginByPassword/index.ts
@@ -1,1 +1,2 @@
-export { useLoginByPassword } from './core/loginByPassword'
+export { loginByPassword } from './core/loginByPassword'
+export { useLoginByPassword } from './core/useLoginByPassword'

--- a/src/entities/auth/api/loginByTemporaryCode/core/loginByTemporaryCode.ts
+++ b/src/entities/auth/api/loginByTemporaryCode/core/loginByTemporaryCode.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { ILoginByTemporaryCodeBody } from '../types/ILoginByTemporaryCodeBody'
 
@@ -10,26 +6,4 @@ const loginByTemporaryCode = createPostFetcher('/auth/temporary/login', 'POST')
 const loginByTemporaryCodeAdapter = (body: ILoginByTemporaryCodeBody) =>
   loginByTemporaryCode({ optionsPost: { body } })
 
-const useLoginByTemporaryCode = (
-  options: TUseMutationOptions<typeof loginByTemporaryCodeAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: loginByTemporaryCodeAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({ message: 'Вы вошли в систему', Icon: UserIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useLoginByTemporaryCode }
+export { loginByTemporaryCodeAdapter as loginByTemporaryCode }

--- a/src/entities/auth/api/loginByTemporaryCode/core/useLoginByTemporaryCode.ts
+++ b/src/entities/auth/api/loginByTemporaryCode/core/useLoginByTemporaryCode.ts
@@ -1,0 +1,30 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { loginByTemporaryCode } from './loginByTemporaryCode'
+
+const useLoginByTemporaryCode = (
+  options: TUseMutationOptions<typeof loginByTemporaryCode> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: loginByTemporaryCode,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({ message: 'Вы вошли в систему', Icon: UserIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useLoginByTemporaryCode }

--- a/src/entities/auth/api/loginByTemporaryCode/index.ts
+++ b/src/entities/auth/api/loginByTemporaryCode/index.ts
@@ -1,1 +1,2 @@
-export { useLoginByTemporaryCode } from './core/loginByTemporaryCode'
+export { loginByTemporaryCode } from './core/loginByTemporaryCode'
+export { useLoginByTemporaryCode } from './core/useLoginByTemporaryCode'

--- a/src/entities/auth/api/logout/core/logout.ts
+++ b/src/entities/auth/api/logout/core/logout.ts
@@ -1,31 +1,7 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 const logout = createPostFetcher('/auth/logout', 'POST')
 const logoutAdapter = () =>
   logout({ optionsPost: { tokenType: 'refreshToken' } })
 
-const useLogout = (options: TUseMutationOptions<typeof logoutAdapter> = {}) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: logoutAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-      ])
-
-      successToast({ message: 'Вы вышли из системы', Icon: UserIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useLogout }
+export { logoutAdapter as logout }

--- a/src/entities/auth/api/logout/core/useLogout.ts
+++ b/src/entities/auth/api/logout/core/useLogout.ts
@@ -1,0 +1,28 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { UserIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { logout } from './logout'
+
+const useLogout = (options: TUseMutationOptions<typeof logout> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: logout,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+      ])
+
+      successToast({ message: 'Вы вышли из системы', Icon: UserIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useLogout }

--- a/src/entities/auth/api/logout/index.ts
+++ b/src/entities/auth/api/logout/index.ts
@@ -1,1 +1,2 @@
-export { useLogout } from './core/logout'
+export { logout } from './core/logout'
+export { useLogout } from './core/useLogout'

--- a/src/entities/profile/api/deleteAvatar/core/deleteAvatar.ts
+++ b/src/entities/profile/api/deleteAvatar/core/deleteAvatar.ts
@@ -1,33 +1,6 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ImageIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 const deleteAvatar = createPostFetcher('/account/avatar', 'DELETE')
 const deleteAvatarAdapter = () => deleteAvatar()
 
-const useDeleteAvatar = (
-  options: TUseMutationOptions<typeof deleteAvatarAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: deleteAvatarAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-      ])
-
-      successToast({ message: 'Аватар удален', Icon: ImageIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useDeleteAvatar }
+export { deleteAvatarAdapter as deleteAvatar }

--- a/src/entities/profile/api/deleteAvatar/core/useDeleteAvatar.ts
+++ b/src/entities/profile/api/deleteAvatar/core/useDeleteAvatar.ts
@@ -1,0 +1,31 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ImageIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { deleteAvatar } from './deleteAvatar'
+
+const useDeleteAvatar = (
+  options: TUseMutationOptions<typeof deleteAvatar> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: deleteAvatar,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+      ])
+
+      successToast({ message: 'Аватар удален', Icon: ImageIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useDeleteAvatar }

--- a/src/entities/profile/api/deleteAvatar/index.ts
+++ b/src/entities/profile/api/deleteAvatar/index.ts
@@ -1,1 +1,2 @@
-export { useDeleteAvatar } from './core/deleteAvatar'
+export { deleteAvatar } from './core/deleteAvatar'
+export { useDeleteAvatar } from './core/useDeleteAvatar'

--- a/src/entities/profile/api/updateAvatar/core/updateAvatar.ts
+++ b/src/entities/profile/api/updateAvatar/core/updateAvatar.ts
@@ -1,8 +1,4 @@
-import { TUseMutationOptions } from '@shared/types'
 import { createPostFetcher } from '@shared/utils/functions'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ImageIcon } from '@shared/icons'
-import { successToast, errorToast } from '@shared/utils/toast'
 
 import { IUpdateAvatarBody } from '../types/IUpdateAvatarBody'
 
@@ -10,27 +6,4 @@ const updateAvatar = createPostFetcher('/account/username', 'PATCH')
 const updateAvatarAdapter = (body: IUpdateAvatarBody) =>
   updateAvatar({ optionsPost: { body } })
 
-const useUpdateAvatar = (
-  options: TUseMutationOptions<typeof updateAvatarAdapter> = {},
-) => {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    ...options,
-    mutationFn: updateAvatarAdapter,
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['account'] }),
-        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
-        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
-      ])
-
-      successToast({ message: 'Аватар обновлен', Icon: ImageIcon })
-    },
-    onError: async ({ message }) => {
-      errorToast({ message })
-    },
-  })
-}
-
-export { useUpdateAvatar }
+export { updateAvatarAdapter as updateAvatar }

--- a/src/entities/profile/api/updateAvatar/core/useUpdateAvatar.ts
+++ b/src/entities/profile/api/updateAvatar/core/useUpdateAvatar.ts
@@ -1,0 +1,31 @@
+import { TUseMutationOptions } from '@shared/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ImageIcon } from '@shared/icons'
+import { successToast, errorToast } from '@shared/utils/toast'
+
+import { updateAvatar } from './updateAvatar'
+
+const useUpdateAvatar = (
+  options: TUseMutationOptions<typeof updateAvatar> = {},
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    ...options,
+    mutationFn: updateAvatar,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['account'] }),
+        queryClient.invalidateQueries({ queryKey: ['account', 'whoami'] }),
+        queryClient.invalidateQueries({ queryKey: ['profile'], exact: false }),
+      ])
+
+      successToast({ message: 'Аватар обновлен', Icon: ImageIcon })
+    },
+    onError: async ({ message }) => {
+      errorToast({ message })
+    },
+  })
+}
+
+export { useUpdateAvatar }

--- a/src/entities/profile/api/updateAvatar/index.ts
+++ b/src/entities/profile/api/updateAvatar/index.ts
@@ -1,1 +1,2 @@
-export { useUpdateAvatar } from './core/updateAvatar'
+export { updateAvatar } from './core/updateAvatar'
+export { useUpdateAvatar } from './core/useUpdateAvatar'


### PR DESCRIPTION
## Summary
- вынес хуки `useMutation` в отдельные файлы `use*`
- оставил в core-файлах только fetcher и адаптеры
- обновил индексы для экспорта fetcher и хуков

## Testing
- `pnpm tsc`
- `pnpm next lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab122e5d94833286ea15ff14268a5c