### PR TITLE
Добавлены aria-атрибуты в UI-компоненты

### DIFF
--- a/src/shared/ui/atoms/Modal/core/DesktopModal/DesktopModal.tsx
+++ b/src/shared/ui/atoms/Modal/core/DesktopModal/DesktopModal.tsx
@@ -16,11 +16,17 @@ const DesktopModal = (props: IModalSolutionProps) => {
     <div
       id={modalID}
       className={cn(st.root, { [st[`root_closing`]]: isModalClosing })}
+      role="dialog"
+      aria-modal="true"
     >
       <div className={st.background} onClick={closeFunction} />
       <div className={st.modalWrapper}>
         <div className={st.modal}>{children}</div>
-        <button onClick={closeFunction} className={st.closeButton}>
+        <button
+          onClick={closeFunction}
+          className={st.closeButton}
+          aria-label="Закрыть модальное окно"
+        >
           <CrossIcon className={st.closeIcon} />
         </button>
       </div>

--- a/src/shared/ui/atoms/Modal/core/MobileModal/MobileModal.tsx
+++ b/src/shared/ui/atoms/Modal/core/MobileModal/MobileModal.tsx
@@ -27,6 +27,8 @@ const MobileModal = (props: IModalSolutionProps) => {
       className={cn(st.root, {
         [st[`root_closing`]]: isModalClosing,
       })}
+      role="dialog"
+      aria-modal="true"
     >
       <div className={st.background} onClick={closeFunction} />
       <div ref={modalRef} className={st.modal} style={modalDragStyle}>
@@ -38,7 +40,11 @@ const MobileModal = (props: IModalSolutionProps) => {
         />
         {children}
       </div>
-      <button onClick={closeFunction} className={st.closeButton}>
+      <button
+        onClick={closeFunction}
+        className={st.closeButton}
+        aria-label="Закрыть модальное окно"
+      >
         <CrossIcon className={st.closeIcon} />
       </button>
     </div>

--- a/src/shared/ui/atoms/Switch/core/Switch.tsx
+++ b/src/shared/ui/atoms/Switch/core/Switch.tsx
@@ -7,7 +7,8 @@ import { useSwitch } from './useSwitch'
 import st from './Switch.module.scss'
 
 const Switch = forwardRef<HTMLButtonElement, ISwitchProps>((props, ref) => {
-  const { variant, className, value, isDisabled, toggle } = useSwitch(props)
+  const { variant, className, value, isDisabled, toggle, ariaLabel } =
+    useSwitch(props)
 
   return (
     <button
@@ -18,6 +19,7 @@ const Switch = forwardRef<HTMLButtonElement, ISwitchProps>((props, ref) => {
       disabled={isDisabled}
       role="switch"
       aria-checked={value}
+      aria-label={ariaLabel}
     >
       <input
         hidden

--- a/src/shared/ui/atoms/Switch/core/useSwitch.ts
+++ b/src/shared/ui/atoms/Switch/core/useSwitch.ts
@@ -7,13 +7,14 @@ const useSwitch = (props: ISwitchProps) => {
     variant = 'big',
     isDisabled = false,
     className,
+    ariaLabel,
   } = props
 
   const toggle = () => {
     onChange(!value)
   }
 
-  return { variant, className, value, isDisabled, toggle }
+  return { variant, className, value, isDisabled, toggle, ariaLabel }
 }
 
 export { useSwitch }

--- a/src/shared/ui/atoms/Switch/types/ISwitchProps.ts
+++ b/src/shared/ui/atoms/Switch/types/ISwitchProps.ts
@@ -5,6 +5,7 @@ interface ISwitchProps {
   variant?: 'big' | 'small'
   isDisabled?: boolean
   className?: string
+  ariaLabel?: string
 }
 
 export type { ISwitchProps }

--- a/src/shared/ui/atoms/ToggleFilters/core/ToggleFilters.tsx
+++ b/src/shared/ui/atoms/ToggleFilters/core/ToggleFilters.tsx
@@ -17,7 +17,11 @@ const ToggleFiltersInner = <T extends string>(
     useToggleFilters(props)
 
   return (
-    <div ref={ref} className={cn(st.root, st[`root_${variant}`], className)}>
+    <div
+      ref={ref}
+      className={cn(st.root, st[`root_${variant}`], className)}
+      role="group"
+    >
       {items.map((tag) => (
         <button
           onClick={() => toggle(tag.value)}
@@ -25,6 +29,8 @@ const ToggleFiltersInner = <T extends string>(
           className={cn(st.tag, {
             [st.tag_active]: isActive(tag.value),
           })}
+          type="button"
+          aria-pressed={isActive(tag.value)}
         >
           {tag.children}
         </button>

--- a/src/shared/ui/molecules/BigButton/core/BigButton.tsx
+++ b/src/shared/ui/molecules/BigButton/core/BigButton.tsx
@@ -18,6 +18,7 @@ const BigButton = forwardRef<HTMLButtonElement, IBigButtonProps>(
       isDisabled,
       iconText,
       type,
+      ariaLabel,
     } = useBigButton(props)
 
     return (
@@ -27,6 +28,7 @@ const BigButton = forwardRef<HTMLButtonElement, IBigButtonProps>(
         onClick={onClick}
         className={cn(st.root, className, st[`root_${variant}`])}
         disabled={isDisabled}
+        aria-label={ariaLabel}
       >
         <div className={st.iconWrapper}>
           <Icon className={st.icon} />

--- a/src/shared/ui/molecules/BigButton/core/useBigButton.ts
+++ b/src/shared/ui/molecules/BigButton/core/useBigButton.ts
@@ -10,6 +10,7 @@ const useBigButton = (props: IBigButtonProps) => {
     isDisabled = false,
     iconText = null,
     type = 'button',
+    ariaLabel,
   } = props
 
   return {
@@ -21,6 +22,7 @@ const useBigButton = (props: IBigButtonProps) => {
     isDisabled,
     iconText,
     type,
+    ariaLabel,
   }
 }
 

--- a/src/shared/ui/molecules/BigButton/types/IBigButtonProps.ts
+++ b/src/shared/ui/molecules/BigButton/types/IBigButtonProps.ts
@@ -11,6 +11,7 @@ interface IBigButtonProps {
   iconText?: string
   className?: string
   type?: 'button' | 'submit' | 'reset'
+  ariaLabel?: string
 }
 
 export type { IBigButtonProps }

--- a/src/shared/ui/molecules/Button/core/Button.tsx
+++ b/src/shared/ui/molecules/Button/core/Button.tsx
@@ -8,8 +8,16 @@ import { useButton } from './useButton'
 import st from './Button.module.scss'
 
 const Button = forwardRef<HTMLButtonElement, TButtonProps>((props, ref) => {
-  const { children, onClick, Icon, className, variant, isDisabled, type } =
-    useButton(props)
+  const {
+    children,
+    onClick,
+    Icon,
+    className,
+    variant,
+    isDisabled,
+    type,
+    ariaLabel,
+  } = useButton(props)
 
   return (
     <button
@@ -18,6 +26,7 @@ const Button = forwardRef<HTMLButtonElement, TButtonProps>((props, ref) => {
       onClick={onClick}
       className={cn(st.root, className, st[`root_${variant}`])}
       disabled={isDisabled}
+      aria-label={ariaLabel}
     >
       {!isNil(Icon) && <Icon className={st.icon} />}
       {!isNil(children) && (

--- a/src/shared/ui/molecules/Button/core/useButton.ts
+++ b/src/shared/ui/molecules/Button/core/useButton.ts
@@ -9,6 +9,7 @@ const useButton = (props: TButtonProps) => {
     variant = 'small',
     isDisabled = false,
     type = 'button',
+    ariaLabel,
   } = props
 
   return {
@@ -19,6 +20,7 @@ const useButton = (props: TButtonProps) => {
     variant,
     isDisabled,
     type,
+    ariaLabel,
   }
 }
 

--- a/src/shared/ui/molecules/Button/types/TButtonProps.ts
+++ b/src/shared/ui/molecules/Button/types/TButtonProps.ts
@@ -7,6 +7,7 @@ interface IButtonPropsBase {
   variant?: 'small' | 'big'
   className?: string
   type?: 'button' | 'submit' | 'reset'
+  ariaLabel?: string
 }
 
 interface IButtonPropsWithChildren extends IButtonPropsBase {

--- a/src/shared/ui/molecules/GlassButton/core/GlassButton.tsx
+++ b/src/shared/ui/molecules/GlassButton/core/GlassButton.tsx
@@ -9,7 +9,7 @@ import st from './GlassButton.module.scss'
 
 const GlassButton = forwardRef<HTMLButtonElement, TGlassButtonProps>(
   (props, ref) => {
-    const { onClick, className, variant, isDisabled, otherProps } =
+    const { onClick, className, variant, isDisabled, ariaLabel, otherProps } =
       useGlassButton(props)
 
     return (
@@ -18,6 +18,7 @@ const GlassButton = forwardRef<HTMLButtonElement, TGlassButtonProps>(
         onClick={onClick}
         className={cn(st.root, className, st[`root_${variant}`])}
         disabled={isDisabled}
+        aria-label={ariaLabel}
       >
         {'children' in otherProps ? (
           <Text weight="700" className={st.children}>

--- a/src/shared/ui/molecules/GlassButton/core/useGlassButton.ts
+++ b/src/shared/ui/molecules/GlassButton/core/useGlassButton.ts
@@ -6,6 +6,7 @@ const useGlassButton = (props: TGlassButtonProps) => {
     className,
     variant = 'small',
     isDisabled = false,
+    ariaLabel,
     ...otherProps
   } = props
 
@@ -14,6 +15,7 @@ const useGlassButton = (props: TGlassButtonProps) => {
     className,
     variant,
     isDisabled,
+    ariaLabel,
     otherProps,
   }
 }

--- a/src/shared/ui/molecules/GlassButton/types/TGlassButtonProps.ts
+++ b/src/shared/ui/molecules/GlassButton/types/TGlassButtonProps.ts
@@ -7,6 +7,7 @@ interface IGlassButtonPropsBase {
   isDisabled?: boolean
   variant?: 'small' | 'big'
   className?: string
+  ariaLabel?: string
 }
 
 interface IGlassButtonPropsWithChildren extends IGlassButtonPropsBase {

--- a/src/shared/ui/molecules/MoreInfo/core/MoreInfo.tsx
+++ b/src/shared/ui/molecules/MoreInfo/core/MoreInfo.tsx
@@ -10,7 +10,7 @@ import { useMoreInfo } from './useMoreInfo'
 import st from './MoreInfo.module.scss'
 
 const MoreInfo = forwardRef<HTMLButtonElement, IMoreInfoProps>((props, ref) => {
-  const { children, label, className, variant } = useMoreInfo(props)
+  const { children, label, className, variant, ariaLabel } = useMoreInfo(props)
 
   return (
     <button
@@ -18,6 +18,7 @@ const MoreInfo = forwardRef<HTMLButtonElement, IMoreInfoProps>((props, ref) => {
       type="button"
       className={cn(st.root, st[`root_${variant}`], className)}
       onClick={() => setModal(children)}
+      aria-label={ariaLabel ?? label}
     >
       <TextSelectIcon className={st.icon} />
       <Text className={st.label}>{label}</Text>

--- a/src/shared/ui/molecules/MoreInfo/core/useMoreInfo.ts
+++ b/src/shared/ui/molecules/MoreInfo/core/useMoreInfo.ts
@@ -1,9 +1,15 @@
 import { IMoreInfoProps } from '../types/IMoreInfoProps'
 
 const useMoreInfo = (props: IMoreInfoProps) => {
-  const { children, label = 'развернуть', className, variant = 'big' } = props
+  const {
+    children,
+    label = 'развернуть',
+    className,
+    variant = 'big',
+    ariaLabel,
+  } = props
 
-  return { children, label, className, variant }
+  return { children, label, className, variant, ariaLabel }
 }
 
 export { useMoreInfo }

--- a/src/shared/ui/molecules/MoreInfo/types/IMoreInfoProps.ts
+++ b/src/shared/ui/molecules/MoreInfo/types/IMoreInfoProps.ts
@@ -6,6 +6,7 @@ interface IMoreInfoProps {
   variant?: 'big' | 'small'
   label?: string
   className?: string
+  ariaLabel?: string
 }
 
 export type { IMoreInfoProps }

--- a/src/shared/ui/molecules/PageLink/core/PageLink.tsx
+++ b/src/shared/ui/molecules/PageLink/core/PageLink.tsx
@@ -30,6 +30,7 @@ const PageLink = (props: IPageLinkProps) => {
         { [st.root_chevron]: isChevronEnabled },
         st[`root_${variant}`],
       )}
+      aria-current={isSelected ? 'page' : undefined}
     >
       {!isNil(Icon) && <Icon className={st.icon} />}
       <Text weight={variant === 'header' ? '700' : '400'} className={st.label}>

--- a/src/shared/ui/molecules/WatchAll/core/WatchAll.tsx
+++ b/src/shared/ui/molecules/WatchAll/core/WatchAll.tsx
@@ -9,7 +9,8 @@ import { useWatchAll } from './useWatchAll'
 import st from './WatchAll.module.scss'
 
 const WatchAll = forwardRef<HTMLButtonElement, IWatchAllProps>((props, ref) => {
-  const { label, type, variant, className, onClick } = useWatchAll(props)
+  const { label, type, variant, className, onClick, ariaLabel } =
+    useWatchAll(props)
 
   return (
     <button
@@ -22,6 +23,7 @@ const WatchAll = forwardRef<HTMLButtonElement, IWatchAllProps>((props, ref) => {
         st[`root_${variant}`],
         className,
       )}
+      aria-label={ariaLabel ?? label}
     >
       <MoveRightIcon className={st.icon} />
       <Text className={st.text}>{label}</Text>

--- a/src/shared/ui/molecules/WatchAll/core/useWatchAll.ts
+++ b/src/shared/ui/molecules/WatchAll/core/useWatchAll.ts
@@ -7,9 +7,10 @@ const useWatchAll = (props: IWatchAllProps) => {
     variant = 'big',
     className,
     onClick,
+    ariaLabel,
   } = props
 
-  return { label, type, variant, className, onClick }
+  return { label, type, variant, className, onClick, ariaLabel }
 }
 
 export { useWatchAll }

--- a/src/shared/ui/molecules/WatchAll/types/IWatchAllProps.ts
+++ b/src/shared/ui/molecules/WatchAll/types/IWatchAllProps.ts
@@ -5,6 +5,7 @@ interface IWatchAllProps {
   type?: 'anime' | 'collection'
   variant?: 'big' | 'small'
   className?: string
+  ariaLabel?: string
 }
 
 export type { IWatchAllProps }

--- a/src/widgets/Header/core/ProfileMenu/core/ProfileMenu.tsx
+++ b/src/widgets/Header/core/ProfileMenu/core/ProfileMenu.tsx
@@ -33,6 +33,9 @@ const ProfileMenu = () => {
           className={cn(st.avatarButton, {
             [st.avatarButton_opened]: isMounted,
           })}
+          aria-label="Меню профиля"
+          aria-haspopup="menu"
+          aria-expanded={isMounted}
         >
           {isSessionLoading ? (
             <Skeleton className={st.avatarSkeleton} />
@@ -52,8 +55,13 @@ const ProfileMenu = () => {
             ref={refs.setFloating}
             style={{ ...floatingStyles, ...transitionStyles }}
             className={st.menu}
+            role="menu"
           >
-            <button className={st.usernameCopy} onClick={copyUsername}>
+            <button
+              className={st.usernameCopy}
+              onClick={copyUsername}
+              aria-label="Скопировать имя пользователя"
+            >
               <Text className={st.username}>{nickname}</Text>
               <CopyIcon className={st.usernameIcon} />
             </button>


### PR DESCRIPTION
## Summary
- улучшена доступность: добавлены aria-атрибуты и роли в модальных окнах, меню профиля и интерактивных кнопках
- расширены типы компонентов для поддержки aria-label

## Testing
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68adebfc6ce083329a0dae40125d5488