### PR TITLE
Add Next.js ESLint plugin configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,17 +2,19 @@ import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import prettierConfig from 'eslint-config-prettier'
 import importPlugin from 'eslint-plugin-import'
+import nextPlugin from '@next/eslint-plugin-next'
 
 export default tseslint.config(
   eslint.configs.recommended,
   tseslint.configs.strict,
   tseslint.configs.stylistic,
-  prettierConfig,
   {
     plugins: {
       import: importPlugin,
+      '@next/next': nextPlugin,
     },
     rules: {
+      ...nextPlugin.configs.recommended.rules,
       '@typescript-eslint/no-invalid-void-type': ['off'],
       '@typescript-eslint/no-empty-object-type': ['off'],
       '@typescript-eslint/no-explicit-any': ['off'],
@@ -47,6 +49,7 @@ export default tseslint.config(
       ],
     },
   },
+  prettierConfig,
   {
     ignores: [
       'node_modules',

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@next/eslint-plugin-next": "15.4.6",
     "@types/react-dom": "^19.1.7",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.33.0
+      '@next/eslint-plugin-next':
+        specifier: 15.4.6
+        version: 15.4.6
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.1.7(@types/react@19.1.10)
@@ -591,6 +594,12 @@ packages:
     resolution:
       {
         integrity: sha512-yHDKVTcHrZy/8TWhj0B23ylKv5ypocuCwey9ZqPyv4rPdUdRzpGCkSi03t04KBPyU96kxVtUqx6O3nE1kpxASQ==,
+      }
+
+  '@next/eslint-plugin-next@15.4.6':
+    resolution:
+      {
+        integrity: sha512-2NOu3ln+BTcpnbIDuxx6MNq+pRrCyey4WSXGaJIyt0D2TYicHeO9QrUENNjcf673n3B1s7hsiV5xBYRCK1Q8kA==,
       }
 
   '@next/mdx@15.4.6':
@@ -2008,6 +2017,13 @@ packages:
       {
         integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==,
       }
+
+  fast-glob@3.3.1:
+    resolution:
+      {
+        integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==,
+      }
+    engines: { node: '>=8.6.0' }
 
   fast-glob@3.3.3:
     resolution:
@@ -4416,6 +4432,10 @@ snapshots:
 
   '@next/env@15.4.6': {}
 
+  '@next/eslint-plugin-next@15.4.6':
+    dependencies:
+      fast-glob: 3.3.1
+
   '@next/mdx@15.4.6(@mdx-js/loader@3.1.0(acorn@8.15.0))(@mdx-js/react@3.1.0(@types/react@19.1.10)(react@19.1.1))':
     dependencies:
       source-map: 0.7.6
@@ -5351,6 +5371,14 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:


### PR DESCRIPTION
## Summary
- add `@next/eslint-plugin-next` dependency
- include Next.js plugin and recommended rules in ESLint flat config

## Testing
- `pnpm lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_68af7a97502083329c1422ce898caf0e